### PR TITLE
Add safety check in Sonar All display update

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -845,7 +845,8 @@ class RepoOverviewApp(App[None]):
 
             # Update the display
             current_widget = self._get_current_widget()
-            current_widget.set_repos(self.repos)
+            if current_widget:
+                current_widget.set_repos(self.repos)
 
             status_bar = self.query_one(StatusBar)
             total_issues = sum(r.open_issues_count for r in self.repos)


### PR DESCRIPTION
## Summary
- Fixed potential crash when updating display after Sonar All (Shift-S) check
- Added null check before calling `set_repos()` on `current_widget`

## Problem
The `action_sonar_all()` method was calling `current_widget.set_repos()` without checking if `current_widget` was None, which could cause silent failures.

## Solution
Added safety check:
```python
if current_widget:
    current_widget.set_repos(self.repos)
```

## Files Affected
- `src/repo_tui/app.py:839`

## Testing
- Tested Shift-S on home machine - sonar results now display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)