### PR TITLE
Rename SonarCloud job for clarity

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sonarcloud:
-    name: SonarCloud Scan
+    name: Run Tests & Submit to SonarCloud
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Rename GitHub Actions job from "SonarCloud Scan" to "Run Tests & Submit to SonarCloud" for better visibility.

## Changes
- Updated `.github/workflows/sonarcloud.yml` job name (line 15)

## Why This Matters
- **Clarity**: Job name now reflects that it runs tests AND submits to SonarCloud
- **Consistency**: Aligns with project_template and other repos
- **User Experience**: Makes it clear what the job does when viewing Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)