### PR TITLE
Add friendly name support for repository display

### DIFF
--- a/src/repo_tui/config.py
+++ b/src/repo_tui/config.py
@@ -54,6 +54,7 @@ class Config:
             "sonar_token_pass": None,  # SonarQube token from pass (e.g., "work/sonarqube")
             "claude_command": "claude",  # Claude CLI command (e.g., "claude" or full path)
             "debug": False,  # Enable debug logging (sonar, claude launcher, etc.)
+            "friendly_names": {},  # Map repo names to friendly display names
         }
         self._save_config(default_config)
         return default_config
@@ -117,3 +118,8 @@ class Config:
                 return None
 
         return None
+
+    def get_friendly_name(self, repo_name: str) -> str | None:
+        """Get the friendly name for a repository, or None if not configured."""
+        friendly_names: dict[str, str] = self.data.get("friendly_names", {})
+        return friendly_names.get(repo_name)

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -465,6 +465,7 @@ async def fetch_all_repos(
             has_uncommitted_changes=has_uncommitted,
             current_branch=current_branch,
             description=description,
+            friendly_name=config.get_friendly_name(repo_name),
         )
 
     # Process in batches to avoid overwhelming the API
@@ -529,6 +530,7 @@ async def fetch_single_repo(
         details_loaded=True,
         has_uncommitted_changes=has_uncommitted,
         current_branch=current_branch,
+        friendly_name=config.get_friendly_name(repo_name),
     )
 
 

--- a/src/repo_tui/models.py
+++ b/src/repo_tui/models.py
@@ -74,6 +74,14 @@ class RepoOverview:
     has_uncommitted_changes: bool = False  # True if local repo has uncommitted changes
     current_branch: str | None = None  # Current git branch if local repo exists
     description: str | None = None  # Repository description
+    friendly_name: str | None = None  # User-configured friendly display name
+
+    @property
+    def display_name(self) -> str:
+        """Get the display name (friendly name if set, otherwise repo name)."""
+        if self.friendly_name:
+            return f"{self.friendly_name} [dim]({self.name})[/dim]"
+        return self.name
 
     @property
     def cloud_env(self) -> str | None:

--- a/src/repo_tui/widgets/repo_grid.py
+++ b/src/repo_tui/widgets/repo_grid.py
@@ -80,7 +80,7 @@ class RepoCard(Static):
         # Build card content - always show name prominently
         lines = [
             "",  # Top padding
-            f"[bold white]{repo.name}[/bold white]",
+            f"[bold white]{repo.display_name}[/bold white]",
             "",
         ]
 

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -140,7 +140,7 @@ class RepoListWidget(OptionList):
             sonar_info = " [dim]No Sonar[/dim]"
 
         text = Text.from_markup(
-            f"{icon} {expand_icon} {repo.name}{lang_tag}{cloud_tag}{counts_badge}{local}{sonar_info}"
+            f"{icon} {expand_icon} {repo.display_name}{lang_tag}{cloud_tag}{counts_badge}{local}{sonar_info}"
         )
         return Option(text, id=f"repo:{repo.name}")
 


### PR DESCRIPTION
## Summary
Implements issue #11 to show user-configured friendly names alongside repository directory names.

## Changes
- Add `friendly_names` config mapping (repo_name → friendly_name)
- Add `get_friendly_name()` method to Config class
- Add `friendly_name` field to RepoOverview model
- Add `display_name` property that formats as "Friendly Name (repo-name)"
- Update both list and grid views to use `display_name`
- Populate `friendly_name` during data fetching in both `fetch_all_repos()` and `fetch_single_repo()`

## Usage
Add to `~/.repo-overview.json`:
```json
{
  "friendly_names": {
    "repo-tui": "Repository Dashboard",
    "job-agent": "Job Processing Agent"
  }
}
```

**Display behavior:**
- With friendly name: `Repository Dashboard (repo-tui)`
- Without friendly name: `repo-tui`

## Testing
- ✅ All 11 tests passing
- ✅ Linting passed (ruff)
- ✅ Type checking passed (mypy)

## Files Modified
- `src/repo_tui/config.py` - Config schema and getter
- `src/repo_tui/models.py` - Model field and display property
- `src/repo_tui/data.py` - Data loading
- `src/repo_tui/widgets/repo_list.py` - List view display
- `src/repo_tui/widgets/repo_grid.py` - Grid view display

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)