### PR TITLE
chore: gitignore launch.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,9 @@ dmyp.json
 # - .claude/settings.local.json is local only (personal overrides)
 .claude/settings.local.json
 
+# Windows Terminal launcher (machine-specific hardcoded path)
+launch.sh
+
 # ==============================================================================
 # SONARCLOUD
 # ==============================================================================


### PR DESCRIPTION
## Summary
- Add `launch.sh` to `.gitignore` — it's a machine-specific Windows Terminal launcher with a hardcoded path

## Test plan
- [x] Pre-commit hooks pass
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)