### PR TITLE
feat: bulk-merge Dependabot PRs across the configured repo list

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -13,10 +13,11 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Footer, Header, LoadingIndicator, Static
+from textual.widgets import Footer, Header, LoadingIndicator, OptionList, Static
 
 from .config import Config
 from .data import fetch_all_repos, fetch_single_repo, format_cache_age
+from .dependabot import MergeResult, merge_all_dependabot_prs
 from .launcher import launch_claude
 from .models import Issue, PullRequest
 from .widgets.repo_grid import RepoGridWidget
@@ -61,6 +62,7 @@ HELP_TEXT = """
   R             Refresh all repos
   s             Check SonarCloud for current repo
   S             Toggle SonarCloud for all repos
+  D             Bulk-merge Dependabot PRs across all repos
   q             Quit
   ?             Show this help
 
@@ -521,6 +523,143 @@ class PRDetailScreen(ModalScreen[int]):
         return text.replace("[", r"\[").replace("]", r"\]")
 
 
+class DependabotMergeScreen(ModalScreen[None]):
+    """Modal that bulk-merges Dependabot PRs and streams per-repo status."""
+
+    BINDINGS = [
+        Binding("escape", "close_modal", "Close"),
+        Binding("q", "close_modal", "Close"),
+    ]
+
+    DEFAULT_CSS = """
+    DependabotMergeScreen {
+        align: center middle;
+    }
+
+    #dependabot-container {
+        width: 90%;
+        height: 85%;
+        max-width: 120;
+        background: $surface;
+        border: solid $primary;
+        padding: 1 2;
+    }
+
+    #dependabot-title {
+        text-style: bold;
+        height: 1;
+        margin-bottom: 1;
+    }
+
+    #dependabot-status {
+        height: 1;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    #dependabot-log-scroll {
+        height: 1fr;
+        border: solid $secondary;
+        padding: 1;
+    }
+
+    #dependabot-log {
+        width: 100%;
+    }
+
+    #dependabot-footer {
+        dock: bottom;
+        height: 1;
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, repos: list[RepoOverview]) -> None:
+        super().__init__()
+        self.target_repos = repos
+        self.log_lines: list[str] = []
+        self.finished = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dependabot-container"):
+            yield Static("Merge Dependabot PRs", id="dependabot-title")
+            yield Static("Starting...", id="dependabot-status")
+            with VerticalScroll(id="dependabot-log-scroll"):
+                yield Static("", id="dependabot-log")
+            yield Static(
+                "[dim]Running — press Esc/q to dismiss when done[/dim]",
+                id="dependabot-footer",
+            )
+
+    def on_mount(self) -> None:
+        self.run_worker(self._run_merger(), exclusive=True)
+
+    async def _run_merger(self) -> None:
+        status = self.query_one("#dependabot-status", Static)
+        total_repos = len(self.target_repos)
+        scanned = 0
+        repos_with_prs = 0
+        merged = 0
+        failed = 0
+
+        async for progress in merge_all_dependabot_prs(self.target_repos):
+            if progress.phase == "scanning":
+                scanned += 1
+                status.update(f"Scanning {scanned}/{total_repos}: {progress.repo_name}")
+                continue
+
+            if progress.phase == "done":
+                if not progress.results:
+                    continue
+                repos_with_prs += 1
+                successes = [r for r in progress.results if r.success]
+                failures = [r for r in progress.results if not r.success]
+
+                for fail in failures:
+                    self._append_log(self._format_failure(progress.repo_name, fail))
+                    failed += 1
+
+                if successes and not failures:
+                    pr_nums = ", ".join(f"#{r.pr_number}" for r in successes)
+                    self._append_log(
+                        f"[green]✓[/green] {progress.repo_name} "
+                        f"All Dependabot PRs Merged ({pr_nums})"
+                    )
+                    merged += len(successes)
+                elif successes:
+                    pr_nums = ", ".join(f"#{r.pr_number}" for r in successes)
+                    self._append_log(
+                        f"[green]✓[/green] {progress.repo_name} "
+                        f"merged {len(successes)} Dependabot PR(s) ({pr_nums})"
+                    )
+                    merged += len(successes)
+
+        self.finished = True
+        summary = (
+            f"Done — scanned {total_repos} repos, "
+            f"{repos_with_prs} had Dependabot PRs, "
+            f"{merged} merged, {failed} failed"
+        )
+        status.update(summary)
+        self._append_log("")
+        self._append_log(f"[bold]{summary}[/bold]")
+        self.query_one("#dependabot-footer", Static).update("[dim]Press Esc/q to close[/dim]")
+
+    def _format_failure(self, repo_name: str, fail: MergeResult) -> str:
+        return (
+            f"[red]✗[/red] {repo_name} "
+            f"PR #{fail.pr_number} unable to merge because of {fail.reason}"
+        )
+
+    def _append_log(self, line: str) -> None:
+        self.log_lines.append(line)
+        self.query_one("#dependabot-log", Static).update("\n".join(self.log_lines))
+        self.query_one("#dependabot-log-scroll", VerticalScroll).scroll_end(animate=False)
+
+    def action_close_modal(self) -> None:
+        self.dismiss()
+
+
 class StatusBar(Static):
     """Status bar showing refresh time and counts."""
 
@@ -594,6 +733,7 @@ class RepoOverviewApp(App[None]):
         Binding("c", "launch", "Claude"),
         Binding("s", "sonar_repo", "Sonar"),
         Binding("S", "sonar_all", "Sonar All"),
+        Binding("D", "merge_dependabot", "Merge Dependabot"),
         Binding("question_mark", "help", "Help"),
         Binding("space", "toggle_expand", "Expand"),
         Binding("1", "switch_view_list", "List", show=False),
@@ -966,7 +1106,25 @@ class RepoOverviewApp(App[None]):
         """Toggle expand/collapse for selected repo (list view only)."""
         if self.view_mode == "list":
             repo_list = self.query_one("#repo-list", RepoListWidget)
+            if repo_list.get_selected_special_action() == "dependabot-merge":
+                await self.action_merge_dependabot()
+                return
             repo_list.toggle_expand()
+
+    async def action_merge_dependabot(self) -> None:
+        """Open the Dependabot bulk-merge modal."""
+        if not self.repos:
+            status_bar = self.query_one(StatusBar)
+            status_bar.update("No repos loaded yet")
+            return
+        await self.push_screen(DependabotMergeScreen(self.repos))
+
+    async def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Trigger the Dependabot merger when the action row is activated."""
+        option_id = event.option.id or ""
+        if option_id == "action:dependabot-merge":
+            event.stop()
+            await self.action_merge_dependabot()
 
     async def action_cursor_down(self) -> None:
         """Move cursor down in current widget."""

--- a/src/repo_tui/dependabot.py
+++ b/src/repo_tui/dependabot.py
@@ -1,0 +1,178 @@
+"""Bulk-merge Dependabot PRs across the configured repo list."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .models import RepoOverview
+
+
+@dataclass
+class MergeResult:
+    """Outcome of attempting to merge a single PR."""
+
+    pr_number: int
+    pr_title: str
+    success: bool
+    reason: str
+
+
+@dataclass
+class RepoProgress:
+    """Progress update emitted as each repo is processed."""
+
+    repo_name: str
+    phase: str  # "scanning" | "done"
+    results: list[MergeResult] = field(default_factory=list)
+
+
+def _is_dependabot_author(author: str | None) -> bool:
+    return "dependabot" in (author or "").lower()
+
+
+def _summarize_checks(rollup: Any) -> str | None:
+    """Collapse a statusCheckRollup blob into SUCCESS/FAILURE/PENDING."""
+    contexts: list[Any] = []
+    if isinstance(rollup, dict):
+        contexts = rollup.get("contexts", []) or []
+    elif isinstance(rollup, list):
+        contexts = rollup
+    if not contexts:
+        return None
+
+    statuses = [c.get("state") or c.get("conclusion") for c in contexts if isinstance(c, dict)]
+    if any(s in ("FAILURE", "failure", "TIMED_OUT") for s in statuses):
+        return "FAILURE"
+    if any(s in ("PENDING", "pending", "IN_PROGRESS") for s in statuses):
+        return "PENDING"
+    non_empty = [s for s in statuses if s]
+    if non_empty and all(s in ("SUCCESS", "success") for s in non_empty):
+        return "SUCCESS"
+    return None
+
+
+async def _list_dependabot_prs(owner: str, repo: str) -> list[dict[str, Any]]:
+    """Live-query open Dependabot PRs for a repo."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        f"{owner}/{repo}",
+        "--author",
+        "app/dependabot",
+        "--state",
+        "open",
+        "--json",
+        "number,title,mergeable,statusCheckRollup,headRefName",
+        "--limit",
+        "100",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await proc.communicate()
+    if proc.returncode != 0:
+        return []
+    try:
+        data = json.loads(stdout.decode())
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _shorten_reason(stderr_text: str, exit_code: int) -> str:
+    """Extract a human-friendly reason from gh's stderr."""
+    msg = stderr_text.strip()
+    lowered = msg.lower()
+
+    if "is not mergeable" in lowered or "merge conflict" in lowered:
+        return "merge conflicts"
+    if "required status check" in lowered and "fail" in lowered:
+        return "required checks failing"
+    if "required status check" in lowered:
+        return "required checks not yet passed"
+    if "review" in lowered and "required" in lowered:
+        return "review required"
+    if "branch protection" in lowered:
+        return "blocked by branch protection"
+    if "not allowed" in lowered and "squash" in lowered:
+        return "squash merge not enabled on this repo"
+    if "is in clean status" in lowered or "is in dirty status" in lowered:
+        return "PR is not in mergeable status"
+
+    first_line = msg.split("\n", 1)[0] if msg else ""
+    return first_line[:120] if first_line else f"gh merge exited {exit_code}"
+
+
+async def _merge_pr(owner: str, repo: str, pr_number: int) -> tuple[bool, str]:
+    """Attempt to squash-merge a PR. Returns (success, reason)."""
+    proc = await asyncio.create_subprocess_exec(
+        "gh",
+        "pr",
+        "merge",
+        str(pr_number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--squash",
+        "--delete-branch",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode == 0:
+        return (True, "merged")
+
+    combined = (stderr.decode() if stderr else "") or (stdout.decode() if stdout else "")
+    return (False, _shorten_reason(combined, proc.returncode or 0))
+
+
+async def merge_all_dependabot_prs(
+    repos: list[RepoOverview],
+) -> AsyncIterator[RepoProgress]:
+    """Iterate repos, merge Dependabot PRs, yield progress per repo.
+
+    Strategy: skip repos with no cached Dependabot PRs (fast path). For the
+    rest, live-query gh for the latest PR state, pre-flight each PR against
+    conflicts/failing/pending checks, then attempt a squash merge. Never
+    rebases or posts comments — purely reports what happened.
+    """
+    for repo in repos:
+        yield RepoProgress(repo.name, "scanning")
+
+        has_cached = any(_is_dependabot_author(pr.author) for pr in (repo.pull_requests or []))
+        if not has_cached:
+            continue
+
+        prs = await _list_dependabot_prs(repo.owner, repo.name)
+        if not prs:
+            continue
+
+        results: list[MergeResult] = []
+        for pr in prs:
+            pr_number = pr.get("number")
+            pr_title = pr.get("title", "")
+            if not isinstance(pr_number, int):
+                continue
+
+            mergeable = pr.get("mergeable")
+            checks = _summarize_checks(pr.get("statusCheckRollup"))
+
+            if mergeable == "CONFLICTING":
+                results.append(MergeResult(pr_number, pr_title, False, "has merge conflicts"))
+                continue
+            if checks == "FAILURE":
+                results.append(MergeResult(pr_number, pr_title, False, "CI checks failing"))
+                continue
+            if checks == "PENDING":
+                results.append(MergeResult(pr_number, pr_title, False, "CI checks still pending"))
+                continue
+
+            success, reason = await _merge_pr(repo.owner, repo.name, pr_number)
+            results.append(MergeResult(pr_number, pr_title, success, reason))
+
+        yield RepoProgress(repo.name, "done", results)

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from ..models import Issue, PullRequest, RepoOverview
 
 
+SPECIAL_ACTION_DEPENDABOT = "dependabot-merge"
+
+
 class RepoListWidget(OptionList):
     """Scrollable list of repositories with status indicators."""
 
@@ -34,11 +37,14 @@ class RepoListWidget(OptionList):
         self.repos = repos
         self._rebuild_options()
         if self.repos:
-            self.highlighted = 0
+            # Land on the first real repo, not the special action row at index 0.
+            self.highlighted = 1
 
     def _rebuild_options(self) -> None:
         """Rebuild the option list from current repos."""
         self.clear_options()
+
+        self.add_option(self._build_dependabot_action_option())
 
         sorted_repos = sorted(
             self.repos,
@@ -64,6 +70,25 @@ class RepoListWidget(OptionList):
                     for issue in repo.issues:
                         issue_option = self._build_issue_option(repo, issue)
                         self.add_option(issue_option)
+
+    def _build_dependabot_action_option(self) -> Option:
+        """Build the special pseudo-row that triggers the Dependabot bulk merger."""
+        text = Text.from_markup(
+            "[bold cyan]⚡ Merge Dependabot PRs[/bold cyan]"
+            " [dim]— bulk-merge across all repos (press Space/Enter)[/dim]"
+        )
+        return Option(text, id=f"action:{SPECIAL_ACTION_DEPENDABOT}")
+
+    def get_selected_special_action(self) -> str | None:
+        """Return the special-action id if the action row is highlighted."""
+        selected = self.highlighted
+        if selected is None:
+            return None
+        option = self.get_option_at_index(selected)
+        option_id: str | None = option.id if option else None
+        if option_id and option_id.startswith("action:"):
+            return option_id.split(":", 1)[1]
+        return None
 
     def _build_repo_option(self, repo: RepoOverview) -> Option:
         """Build a rich option for a repository."""

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Dependabot bulk-merger."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repo_tui.dependabot import (
+    _is_dependabot_author,
+    _shorten_reason,
+    _summarize_checks,
+    merge_all_dependabot_prs,
+)
+from repo_tui.models import PullRequest, RepoOverview
+
+
+def _make_repo(name: str, prs: list[PullRequest] | None = None) -> RepoOverview:
+    return RepoOverview(
+        name=name,
+        owner="test-owner",
+        url=f"https://github.com/test-owner/{name}",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        pull_requests=prs,
+    )
+
+
+def _dependabot_pr(number: int = 1) -> PullRequest:
+    return PullRequest(
+        number=number,
+        title=f"Bump something to {number}.0.0",
+        url=f"https://github.com/test-owner/x/pull/{number}",
+        author="dependabot[bot]",
+        state="OPEN",
+    )
+
+
+def test_is_dependabot_author_variants():
+    assert _is_dependabot_author("dependabot[bot]")
+    assert _is_dependabot_author("Dependabot")
+    assert _is_dependabot_author("app/dependabot")
+    assert not _is_dependabot_author("renovate[bot]")
+    assert not _is_dependabot_author("")
+    assert not _is_dependabot_author(None)
+
+
+def test_summarize_checks_handles_dict_and_list():
+    passing_dict = {"contexts": [{"conclusion": "SUCCESS"}, {"state": "success"}]}
+    assert _summarize_checks(passing_dict) == "SUCCESS"
+
+    failing_list = [{"state": "FAILURE"}, {"state": "SUCCESS"}]
+    assert _summarize_checks(failing_list) == "FAILURE"
+
+    pending = [{"state": "PENDING"}, {"state": "SUCCESS"}]
+    assert _summarize_checks(pending) == "PENDING"
+
+    assert _summarize_checks({}) is None
+    assert _summarize_checks([]) is None
+    assert _summarize_checks(None) is None
+
+
+def test_shorten_reason_known_patterns():
+    assert _shorten_reason("Pull request is not mergeable", 1) == "merge conflicts"
+    assert (
+        _shorten_reason("required status check 'lint' is failing", 1) == "required checks failing"
+    )
+    assert _shorten_reason("review is required before merging", 1) == "review required"
+    assert (
+        _shorten_reason("blocked by branch protection rules", 1) == "blocked by branch protection"
+    )
+    # Unknown message falls back to the first line
+    assert _shorten_reason("something totally weird happened", 1) == (
+        "something totally weird happened"
+    )
+    assert _shorten_reason("", 7) == "gh merge exited 7"
+
+
+@pytest.mark.asyncio
+async def test_merger_skips_repos_without_cached_dependabot_prs():
+    repos = [_make_repo("no-deps", prs=[])]
+    progress = [p async for p in merge_all_dependabot_prs(repos)]
+    # One scanning event, no "done" event (skipped).
+    assert [p.phase for p in progress] == ["scanning"]
+
+
+@pytest.mark.asyncio
+async def test_merger_reports_merge_success():
+    repos = [_make_repo("has-deps", prs=[_dependabot_pr(1)])]
+
+    live_prs = [
+        {
+            "number": 1,
+            "title": "Bump x to 2.0.0",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [{"state": "SUCCESS"}],
+        }
+    ]
+
+    with (
+        patch(
+            "repo_tui.dependabot._list_dependabot_prs",
+            new=AsyncMock(return_value=live_prs),
+        ),
+        patch(
+            "repo_tui.dependabot._merge_pr",
+            new=AsyncMock(return_value=(True, "merged")),
+        ),
+    ):
+        progress = [p async for p in merge_all_dependabot_prs(repos)]
+
+    done_events = [p for p in progress if p.phase == "done"]
+    assert len(done_events) == 1
+    assert done_events[0].repo_name == "has-deps"
+    assert len(done_events[0].results) == 1
+    assert done_events[0].results[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_merger_preflight_blocks_on_conflicts_and_failing_ci():
+    repos = [_make_repo("has-deps", prs=[_dependabot_pr(1), _dependabot_pr(2)])]
+
+    live_prs = [
+        {
+            "number": 1,
+            "title": "conflict PR",
+            "mergeable": "CONFLICTING",
+            "statusCheckRollup": [{"state": "SUCCESS"}],
+        },
+        {
+            "number": 2,
+            "title": "ci-failing PR",
+            "mergeable": "MERGEABLE",
+            "statusCheckRollup": [{"state": "FAILURE"}],
+        },
+    ]
+
+    merge_mock = AsyncMock(return_value=(True, "merged"))
+    with (
+        patch(
+            "repo_tui.dependabot._list_dependabot_prs",
+            new=AsyncMock(return_value=live_prs),
+        ),
+        patch("repo_tui.dependabot._merge_pr", new=merge_mock),
+    ):
+        progress = [p async for p in merge_all_dependabot_prs(repos)]
+
+    # No actual merge call should happen — both PRs blocked in pre-flight.
+    merge_mock.assert_not_called()
+
+    done = next(p for p in progress if p.phase == "done")
+    assert len(done.results) == 2
+    reasons = {r.pr_number: r.reason for r in done.results}
+    assert reasons[1] == "has merge conflicts"
+    assert reasons[2] == "CI checks failing"
+    assert all(r.success is False for r in done.results)

--- a/tests/test_repo_list_widget.py
+++ b/tests/test_repo_list_widget.py
@@ -1,0 +1,56 @@
+"""Tests for the repo-list widget's special Dependabot action row."""
+
+from __future__ import annotations
+
+import pytest
+
+from repo_tui.app import RepoOverviewApp
+from repo_tui.models import RepoOverview
+from repo_tui.widgets.repo_list import RepoListWidget
+
+
+def _repo(name: str) -> RepoOverview:
+    return RepoOverview(
+        name=name,
+        owner="test-owner",
+        url=f"https://github.com/test-owner/{name}",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        pull_requests=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_action_row_appears_first_and_is_not_a_repo():
+    repos = [_repo("alpha"), _repo("beta")]
+    app = RepoOverviewApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.query_one("#repo-list", RepoListWidget)
+        widget.set_repos(repos)
+        await pilot.pause()
+
+        first = widget.get_option_at_index(0)
+        assert first is not None
+        assert first.id == "action:dependabot-merge"
+
+        # Highlight defaults to index 1 (first real repo), not the action row.
+        assert widget.highlighted == 1
+        assert widget.get_selected_repo() is not None
+        assert widget.get_selected_special_action() is None
+
+
+@pytest.mark.asyncio
+async def test_action_row_detected_when_highlighted():
+    repos = [_repo("alpha")]
+    app = RepoOverviewApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        widget = app.query_one("#repo-list", RepoListWidget)
+        widget.set_repos(repos)
+        await pilot.pause()
+
+        widget.highlighted = 0
+        assert widget.get_selected_special_action() == "dependabot-merge"
+        assert widget.get_selected_repo() is None


### PR DESCRIPTION
## Summary
- Adds a new **⚡ Merge Dependabot PRs** pseudo-row at the top of the list view and a `D` keybind that opens a modal bulk-merger.
- The merger walks the same filtered repo list the TUI already shows (`included_repos`/`excluded_repos`) and squash-merges eligible Dependabot PRs via `gh pr merge --squash --delete-branch`.
- Per-repo progress streams into the modal: `✓ <repo> All Dependabot PRs Merged` on success, `✗ <repo> PR #N unable to merge because of <reason>` on failure, with reasons parsed from `gh` stderr (conflicts, failing CI, pending CI, review required, branch protection, etc.).
- Pre-flight checks (`mergeable == CONFLICTING`, CI `FAILURE`/`PENDING`) short-circuit the gh call so obviously-blocked PRs don't even attempt to merge.
- Never rebases and never posts comments — by design: failures are reported, not worked around, so PRs aren't left in a weirder state than they started.

## Changes
- `src/repo_tui/dependabot.py` *(new)* — async iterator that yields per-repo progress with `MergeResult` dataclasses.
- `src/repo_tui/widgets/repo_list.py` — adds the special action row at index 0; default highlight lands on the first real repo (index 1).
- `src/repo_tui/app.py` — adds `DependabotMergeScreen` modal, `action_merge_dependabot`, `D` binding, Space/Enter on the action row, and `on_option_list_option_selected` handler.
- `tests/test_dependabot.py` *(new)* — covers author detection, check-rollup summarization, reason shortening, and the iterator's skip / success / pre-flight-blocking paths.
- `tests/test_repo_list_widget.py` *(new)* — verifies the pseudo-row appears at index 0, default highlight is on the first repo, and `get_selected_special_action` flips correctly.

## Test plan
- [x] `./test.sh` — all 19 tests pass (11 existing + 8 new).
- [x] `ruff check` / `ruff format --check` / `mypy` all clean.
- [ ] Manual: run `./run.sh`, verify pseudo-row renders at top of list and that Space on it opens the modal.
- [ ] Manual: verify `D` keybind opens the modal from anywhere in the list/grid view.
- [ ] Manual: run against a repo with a real mergeable Dependabot PR and confirm it's merged with branch deletion.
- [ ] Manual: run against a repo with a conflicting/failing Dependabot PR and confirm the reason is reported correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)