### PR TITLE
feat: add y-to-copy keybind to Dependabot merge modal

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -529,6 +529,7 @@ class DependabotMergeScreen(ModalScreen[None]):
     BINDINGS = [
         Binding("escape", "close_modal", "Close"),
         Binding("q", "close_modal", "Close"),
+        Binding("y", "copy_log", "Copy"),
     ]
 
     DEFAULT_CSS = """
@@ -587,7 +588,7 @@ class DependabotMergeScreen(ModalScreen[None]):
             with VerticalScroll(id="dependabot-log-scroll"):
                 yield Static("", id="dependabot-log")
             yield Static(
-                "[dim]Running — press Esc/q to dismiss when done[/dim]",
+                "[dim]Running — y copy | Esc/q close[/dim]",
                 id="dependabot-footer",
             )
 
@@ -643,7 +644,7 @@ class DependabotMergeScreen(ModalScreen[None]):
         status.update(summary)
         self._append_log("")
         self._append_log(f"[bold]{summary}[/bold]")
-        self.query_one("#dependabot-footer", Static).update("[dim]Press Esc/q to close[/dim]")
+        self.query_one("#dependabot-footer", Static).update("[dim]y copy | Esc/q close[/dim]")
 
     def _format_failure(self, repo_name: str, fail: MergeResult) -> str:
         return (
@@ -658,6 +659,21 @@ class DependabotMergeScreen(ModalScreen[None]):
 
     def action_close_modal(self) -> None:
         self.dismiss()
+
+    def action_copy_log(self) -> None:
+        """Copy the log to the system clipboard via OSC 52."""
+        from rich.text import Text
+
+        plain_lines = [Text.from_markup(line).plain for line in self.log_lines]
+        plain_text = "\n".join(plain_lines).strip()
+        if not plain_text:
+            return
+        self.app.copy_to_clipboard(plain_text)
+        footer = self.query_one("#dependabot-footer", Static)
+        suffix = "Esc/q close" if self.finished else "Esc/q dismiss"
+        footer.update(
+            f"[green]✓ Copied {len(plain_lines)} lines to clipboard[/green] [dim]| {suffix}[/dim]"
+        )
 
 
 class StatusBar(Static):

--- a/tests/test_repo_list_widget.py
+++ b/tests/test_repo_list_widget.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from repo_tui.app import RepoOverviewApp
+from repo_tui.app import DependabotMergeScreen, RepoOverviewApp
 from repo_tui.models import RepoOverview
 from repo_tui.widgets.repo_list import RepoListWidget
 
@@ -54,3 +56,55 @@ async def test_action_row_detected_when_highlighted():
         widget.highlighted = 0
         assert widget.get_selected_special_action() == "dependabot-merge"
         assert widget.get_selected_repo() is None
+
+
+@pytest.mark.asyncio
+async def test_dependabot_modal_copy_action_strips_markup():
+    """Pressing y on the modal copies plaintext (no Rich markup) to clipboard."""
+    app = RepoOverviewApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = DependabotMergeScreen(repos=[])
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        # Inject log lines with markup so we can verify it's stripped.
+        screen.log_lines = [
+            "[green]✓[/green] alpha All Dependabot PRs Merged (#1, #2)",
+            "[red]✗[/red] beta PR #3 unable to merge because of merge conflicts",
+        ]
+
+        fake_clipboard = MagicMock()
+        app.copy_to_clipboard = fake_clipboard  # type: ignore[method-assign]
+
+        screen.action_copy_log()
+
+        fake_clipboard.assert_called_once()
+        copied = fake_clipboard.call_args[0][0]
+        assert "[green]" not in copied
+        assert "[/green]" not in copied
+        assert "✓ alpha All Dependabot PRs Merged (#1, #2)" in copied
+        assert "✗ beta PR #3 unable to merge because of merge conflicts" in copied
+
+
+@pytest.mark.asyncio
+async def test_dependabot_modal_copy_skips_when_empty():
+    """Copy action is a no-op when the log is empty (nothing to paste)."""
+    app = RepoOverviewApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        screen = DependabotMergeScreen(repos=[])
+        await app.push_screen(screen)
+        await pilot.pause()
+
+        # Force an empty log — simulates the case before any results stream in.
+        screen.log_lines = []
+
+        fake_clipboard = MagicMock()
+        app.copy_to_clipboard = fake_clipboard  # type: ignore[method-assign]
+
+        screen.action_copy_log()
+
+        fake_clipboard.assert_not_called()


### PR DESCRIPTION
## Summary
- Textual captures mouse events inside the app, so text in the Dependabot merge modal couldn't be selected with the mouse.
- Adds a `y` (yank) keybind that strips Rich markup from the log and copies the plaintext to the system clipboard via Textual's OSC 52 support — works in Windows Terminal, tmux, and over SSH.
- Footer hint now reads `y copy | Esc/q close` so the binding is discoverable.

## Changes
- `src/repo_tui/app.py` — new `Binding(\"y\", \"copy_log\", \"Copy\")` on `DependabotMergeScreen`, plus `action_copy_log()` that joins log lines, converts `Text.from_markup(line).plain` to strip markup, and calls `self.app.copy_to_clipboard()`. Footer updates to confirm how many lines were copied.
- `tests/test_repo_list_widget.py` — two new tests: one verifies markup is stripped and plaintext is handed to `copy_to_clipboard`; one verifies the action is a no-op when the log is empty.

## Test plan
- [x] `./test.sh` — all 21 tests pass.
- [x] `ruff check` / `ruff format --check` / `mypy` clean.
- [ ] Manual: trigger the merge modal, press `y` after results stream in, paste into another app to confirm plaintext (no `[green]`/`[/green]` markup).
- [ ] Manual: confirm the footer briefly shows \"✓ Copied N lines to clipboard\" after `y` is pressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)