### PR TITLE
feat: log every repo in Dependabot merge modal

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -610,6 +610,7 @@ class DependabotMergeScreen(ModalScreen[None]):
 
             if progress.phase == "done":
                 if not progress.results:
+                    self._append_log(f"[dim]- {progress.repo_name} no open Dependabot PRs[/dim]")
                     continue
                 repos_with_prs += 1
                 successes = [r for r in progress.results if r.success]

--- a/src/repo_tui/dependabot.py
+++ b/src/repo_tui/dependabot.py
@@ -146,10 +146,12 @@ async def merge_all_dependabot_prs(
 
         has_cached = any(_is_dependabot_author(pr.author) for pr in (repo.pull_requests or []))
         if not has_cached:
+            yield RepoProgress(repo.name, "done", [])
             continue
 
         prs = await _list_dependabot_prs(repo.owner, repo.name)
         if not prs:
+            yield RepoProgress(repo.name, "done", [])
             continue
 
         results: list[MergeResult] = []

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -78,11 +78,31 @@ def test_shorten_reason_known_patterns():
 
 
 @pytest.mark.asyncio
-async def test_merger_skips_repos_without_cached_dependabot_prs():
+async def test_merger_emits_empty_done_for_repos_without_dependabot_prs():
+    """Every repo should emit a done event so the modal can log it was checked."""
     repos = [_make_repo("no-deps", prs=[])]
     progress = [p async for p in merge_all_dependabot_prs(repos)]
-    # One scanning event, no "done" event (skipped).
-    assert [p.phase for p in progress] == ["scanning"]
+    # Scanning, then done with empty results (nothing to merge, but logged).
+    assert [p.phase for p in progress] == ["scanning", "done"]
+    done = progress[1]
+    assert done.repo_name == "no-deps"
+    assert done.results == []
+
+
+@pytest.mark.asyncio
+async def test_merger_emits_empty_done_when_live_query_returns_nothing():
+    """Repo had cached Dependabot PRs but live query finds none (already merged)."""
+    repos = [_make_repo("stale-cache", prs=[_dependabot_pr(1)])]
+
+    with patch(
+        "repo_tui.dependabot._list_dependabot_prs",
+        new=AsyncMock(return_value=[]),
+    ):
+        progress = [p async for p in merge_all_dependabot_prs(repos)]
+
+    done = next(p for p in progress if p.phase == "done")
+    assert done.repo_name == "stale-cache"
+    assert done.results == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Previously the Dependabot merge modal silently skipped repos with no open Dependabot PRs, so the user couldn't tell whether a repo had been scanned or not — only the repos with actual results appeared in the log.
- Now every repo gets one line in the log, so the full list doubles as an audit trail:
  - `- <repo> no open Dependabot PRs` (dim) when there's nothing to do
  - `✓ <repo> All Dependabot PRs Merged (#N, ...)` on full success
  - `✗ <repo> PR #N unable to merge because of <reason>` on failure
- Both skip paths (no cached Dependabot PRs, and live query returned nothing) now emit a `done` progress event with empty results — the merger treats them uniformly.

## Changes
- `src/repo_tui/dependabot.py` — emit `RepoProgress(repo, "done", [])` in both skip branches instead of falling through silently.
- `src/repo_tui/app.py` — `DependabotMergeScreen._run_merger` logs a muted "no open Dependabot PRs" line when `progress.results` is empty.
- `tests/test_dependabot.py` — updated the existing skip test to assert a `done` event is emitted; added a second test for the live-query-empty branch.

## Test plan
- [x] `./test.sh` — 20 tests pass.
- [x] `ruff check` / `ruff format --check` / `mypy` clean.
- [ ] Manual: trigger the modal across ~29 repos, verify every repo gets one line and the final summary counts (`N had Dependabot PRs`) matches the number of non-dim lines.

## Related
- Follow-up to the Dependabot merger shipped in #33.
- Stacks cleanly on top of #34 (the `y`-copy feature); minor merge whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)