### PR TITLE
chore: cut Dependabot-driven CI load

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,25 +26,15 @@ updates:
       prefix-development: "chore"
       include: "scope"
 
-    # Group related dependencies together
+    # Bundle all minor+patch updates into a single weekly PR to cut CI load.
+    # Major updates still open as individual PRs (they're usually breaking).
     groups:
-      # Group all pytest-related packages
-      pytest:
+      all-minor-patch:
         patterns:
-          - "pytest*"
-
-      # Group development dependencies (minor and patch updates only)
-      development:
-        dependency-type: "development"
+          - "*"
         update-types:
           - "minor"
           - "patch"
-
-      # Group security-related packages
-      security:
-        patterns:
-          - "bandit*"
-          - "safety"
 
     # Ignore specific dependencies or versions
     # Uncomment and customize as needed:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,10 @@ concurrency:
 jobs:
   security-scan:
     name: Security Analysis
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Skip on draft PRs and on Dependabot PRs — Bandit scans src/, not deps,
+    # so dep bumps produce no new findings. The weekly scheduled cron still
+    # runs a full scan on main.
+    if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Two small config changes that together should roughly halve GitHub Actions minutes consumed by the weekly Dependabot cycle. Motivation: hit the monthly Actions cap last night; most of the burn was CI fanning out across per-package Dependabot PRs plus redundant Bandit runs.

## Changes

### A. `dependabot.yml` — one grouped PR per week
- Replace the three narrow groups (`pytest`, `development`, `security`) with a single catch-all `all-minor-patch` group that bundles **every** minor/patch update into one weekly PR.
- Major updates still open as individual PRs — they're usually breaking and warrant isolated review.
- **Effect:** 1 Dependabot PR/week instead of the ~5 we saw last cycle → ~80% fewer Dependabot-triggered CI runs.

### B. `security.yml` — skip Bandit on Dependabot PRs
- Adds `github.actor != 'dependabot[bot]'` to the existing guard (mirrors what `sonarcloud.yml` already does).
- Rationale: Bandit scans `src/`, not dependencies — a dep bump produces no new findings. The existing **weekly scheduled cron on main** still runs a full scan, so coverage isn't lost.
- **Effect:** ~3 Actions minutes saved per Dependabot PR.

## Tradeoffs
- Group-all means one failing minor/patch update blocks all of them that week until resolved. For a solo repo with mostly stable deps, this is rarely a real cost — and Dependabot will regenerate the PR on the next cycle.
- Skipping Bandit on Dependabot PRs relies on the weekly cron. If a critical Bandit finding somehow correlates with a dep bump (extremely unlikely since Bandit doesn't scan deps), it'd be caught on the next Monday run instead of instantly.

## Test plan
- [x] YAML syntax validated (`python -c \"import yaml; yaml.safe_load(...)\"` on both files).
- [ ] Observe next weekly Dependabot run (Monday ${{ today's_date_plus }}) — expect a single grouped PR rather than multiple.
- [ ] Open a test PR authored by Dependabot and verify the Security Scanning workflow is skipped while CI still runs.

## Not in scope
- Option C from the discussion (drop `push: branches: [main]` from `sonarcloud.yml`). Smaller win and mildly debatable — happy to do in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)