### PR TITLE
chore(ci): skip CI workflows on .github/** changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     branches: [main]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   workflow_dispatch:  # Allow manual triggers
 
 concurrency:


### PR DESCRIPTION
## Summary
- Adds `.github/**` to `paths-ignore` in `ci.yml` so workflow-only PRs skip heavy gates cleanly.
- Mirrors [project_template PR #69](https://github.com/adamkwhite/project_template/pull/69).

## Notes
- `security.yml` and `sonarcloud.yml` do not have a `paths-ignore` filter; per the rollout rule, no filter is added from scratch.
- `security.yml` triggers include `pull_request` (plus `schedule`/`workflow_dispatch`), so it is not skip-only.
- `sonarcloud.yml` triggers on `push`/`pull_request`/`workflow_dispatch`.

## Test plan
- [ ] CI lint job runs on this PR (touches `ci.yml` itself, so it should still execute on this PR).
- [ ] After merge, future workflow-only PRs (changing only `.github/**`) skip CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)