### PR TITLE
chore(ci): add paths-ignore to workflows that lacked one

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,7 @@ name: Security Scanning
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   schedule:
     # Run weekly on Mondays at 9am UTC
     - cron: '0 9 * * 1'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     branches:
       - main
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to `security.yml` (pull_request) and `sonarcloud.yml` (push + pull_request) so PRs that only touch docs, LICENSE, gitignore, or `.github/**` files skip the heavy gates.
- Matches the project_template idiom; leaves `schedule:` and `workflow_dispatch:` triggers untouched.

## Test plan
- [ ] CI green on this PR (sonarcloud job should still run since this PR modifies `.github/**` only on the *current* commit, but the trigger filters apply to *future* PRs).
- [ ] Future docs-only PRs skip security and sonarcloud gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)