### PR TITLE
feat: surface local-only repos and match checkouts by remote URL

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -6,6 +6,7 @@ import asyncio
 import atexit
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from textual import events
@@ -929,6 +930,7 @@ class RepoOverviewApp(App[None]):
                 selected_repo.owner,
                 selected_repo.name,
                 self.check_sonar,
+                local_path=Path(selected_repo.local_path) if selected_repo.local_path else None,
             )
 
             # Replace the repo in our list
@@ -986,6 +988,7 @@ class RepoOverviewApp(App[None]):
                 selected_repo.owner,
                 selected_repo.name,
                 check_sonar=True,
+                local_path=Path(selected_repo.local_path) if selected_repo.local_path else None,
             )
 
             # Replace the repo in our list

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import json
+import re
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Coroutine
@@ -22,6 +23,24 @@ ProgressCallback = Callable[[int, int, str], Coroutine[Any, Any, None]]
 
 CACHE_DIR = Path("~/.cache/repo-tui").expanduser()
 CACHE_FILE = CACHE_DIR / "repos.json"
+
+# Sentinel owner used for repos that exist locally but have no GitHub remote.
+LOCAL_ONLY_OWNER = "local"
+
+_GITHUB_ORIGIN_RE = re.compile(
+    r"^(?:git@github\.com:|https?://(?:[^@/]+@)?github\.com/)([^/]+)/(.+?)(?:\.git)?/?$"
+)
+
+
+def parse_github_origin(origin: str) -> tuple[str, str] | None:
+    """Parse a GitHub remote URL into (owner, repo) — preserves case.
+
+    Returns None for non-GitHub URLs.
+    """
+    match = _GITHUB_ORIGIN_RE.match(origin.strip())
+    if not match:
+        return None
+    return match.group(1), match.group(2)
 
 
 class NetworkError(Exception):
@@ -82,6 +101,90 @@ def _dict_to_repo(d: dict) -> RepoOverview:
         friendly_name=d.get("friendly_name"),
         pushed_at=d.get("pushed_at"),
     )
+
+
+async def _git_origin_url(repo_path: Path) -> str | None:
+    """Return the origin remote URL for a local git repo, or None if not set."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(repo_path),
+            "remote",
+            "get-url",
+            "origin",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return None
+        url = stdout.decode().strip()
+        return url or None
+    except Exception:
+        return None
+
+
+async def _git_last_commit_iso(repo_path: Path) -> str | None:
+    """Return the ISO 8601 commit date of HEAD, or None on error."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(repo_path),
+            "log",
+            "-1",
+            "--format=%cI",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return None
+        value = stdout.decode().strip()
+        return value or None
+    except Exception:
+        return None
+
+
+class LocalRepoScan(NamedTuple):
+    """Result of scanning the local code path for git repos."""
+
+    by_owner_repo: dict[tuple[str, str], Path]
+    local_only: list[Path]
+
+
+async def scan_local_repos(local_code_path: Path) -> LocalRepoScan:
+    """Scan the local code path for git repositories.
+
+    Returns:
+        LocalRepoScan with:
+        - by_owner_repo: maps (owner_lower, name_lower) -> local path for repos
+          whose origin points at a GitHub URL. Used to find local checkouts even
+          when the directory name differs from the GitHub repo name.
+        - local_only: paths for repos with no remote, or with a non-GitHub remote.
+    """
+    scan = LocalRepoScan(by_owner_repo={}, local_only=[])
+    if not local_code_path.exists() or not local_code_path.is_dir():
+        return scan
+
+    candidates = [
+        entry for entry in local_code_path.iterdir() if entry.is_dir() and (entry / ".git").exists()
+    ]
+    if not candidates:
+        return scan
+
+    origins = await asyncio.gather(*(_git_origin_url(p) for p in candidates))
+
+    for path, origin in zip(candidates, origins, strict=True):
+        parsed = parse_github_origin(origin) if origin else None
+        if parsed:
+            owner, name = parsed
+            scan.by_owner_repo[(owner.lower(), name.lower())] = path
+        else:
+            scan.local_only.append(path)
+
+    return scan
 
 
 def format_cache_age(timestamp: str | None) -> str:
@@ -458,6 +561,45 @@ class SonarCloudClient:
         return patterns
 
 
+async def _build_local_only_overviews(
+    config: Config,
+    paths: list[Path],
+) -> list[RepoOverview]:
+    """Build RepoOverview entries for local repos that have no GitHub remote."""
+    if not paths:
+        return []
+
+    github = GitHubClient(config)
+    overviews: list[RepoOverview] = []
+
+    async def build_one(path: Path) -> RepoOverview | None:
+        name = path.name
+        if not config.should_include_repo(name):
+            return None
+        has_uncommitted, current_branch = await github.get_git_status(path)
+        pushed_at = await _git_last_commit_iso(path)
+        return RepoOverview(
+            name=name,
+            owner=LOCAL_ONLY_OWNER,
+            url="",
+            open_issues_count=0,
+            issues=[],
+            sonar_status=None,
+            local_path=str(path),
+            sonar_checked=False,
+            pull_requests=[],
+            details_loaded=True,
+            has_uncommitted_changes=has_uncommitted,
+            current_branch=current_branch,
+            friendly_name=config.get_friendly_name(name),
+            pushed_at=pushed_at,
+        )
+
+    results = await asyncio.gather(*(build_one(p) for p in paths))
+    overviews.extend(r for r in results if r is not None)
+    return overviews
+
+
 async def fetch_all_repos(
     config: Config,
     check_sonar: bool = False,
@@ -507,6 +649,12 @@ async def fetch_all_repos(
 
     total = len(repos)
 
+    # Scan local code path once: lets us match a checkout to its remote even when
+    # the directory name differs from the GitHub repo name (e.g. local
+    # "kafka-food-pipeline" -> remote "KafkaFoodPipeline"), and surface dirs
+    # whose origin isn't on GitHub at all.
+    local_scan = await scan_local_repos(config.get_local_code_path())
+
     # Parallel fetch: create tasks for all repos
     async def fetch_repo_data(repo_data: dict[str, Any]) -> RepoOverview:
         repo_name = repo_data["name"]
@@ -522,7 +670,10 @@ async def fetch_all_repos(
 
         issues, pull_requests = await asyncio.gather(issues_task, prs_task)
 
-        local_path = github.get_local_repo_path(repo_name)
+        local_path = local_scan.by_owner_repo.get((owner.lower(), repo_name.lower()))
+        if local_path is None:
+            # Fall back to directory-name match for repos with no remote URL set.
+            local_path = github.get_local_repo_path(repo_name)
         primary_lang = repo_data.get("primaryLanguage")
         language = primary_lang.get("name") if primary_lang else None
         topics_data = repo_data.get("repositoryTopics", [])
@@ -590,6 +741,11 @@ async def fetch_all_repos(
         batch_results = await asyncio.gather(*[fetch_repo_data(r) for r in batch])
         overviews.extend(batch_results)
 
+    # Add local-only repos (dirs with no GitHub remote) so they show up alongside
+    # GitHub-backed repos. They have no issues/PRs/Sonar — just git status.
+    local_only_overviews = await _build_local_only_overviews(config, local_scan.local_only)
+    overviews.extend(local_only_overviews)
+
     # Sort by most recently pushed first
     overviews.sort(key=lambda r: r.pushed_at or "", reverse=True)
 
@@ -604,17 +760,46 @@ async def fetch_single_repo(
     owner: str,
     repo_name: str,
     check_sonar: bool = False,
+    local_path: Path | None = None,
 ) -> RepoOverview:
     """Fetch data for a single repository.
 
     Args:
         config: Configuration object
-        owner: Repository owner
+        owner: Repository owner (use LOCAL_ONLY_OWNER for local-only repos)
         repo_name: Repository name
         check_sonar: Whether to check SonarCloud status
+        local_path: Override for the local checkout path. Required when
+            owner == LOCAL_ONLY_OWNER (since the directory name may differ
+            from anything on GitHub).
     """
     github = GitHubClient(config)
     sonar = SonarCloudClient(config)
+
+    if owner == LOCAL_ONLY_OWNER:
+        path = local_path or github.get_local_repo_path(repo_name)
+        has_uncommitted = False
+        current_branch = None
+        pushed_at = None
+        if path:
+            has_uncommitted, current_branch = await github.get_git_status(path)
+            pushed_at = await _git_last_commit_iso(path)
+        return RepoOverview(
+            name=repo_name,
+            owner=LOCAL_ONLY_OWNER,
+            url="",
+            open_issues_count=0,
+            issues=[],
+            sonar_status=None,
+            local_path=str(path) if path else None,
+            sonar_checked=False,
+            pull_requests=[],
+            details_loaded=True,
+            has_uncommitted_changes=has_uncommitted,
+            current_branch=current_branch,
+            friendly_name=config.get_friendly_name(repo_name),
+            pushed_at=pushed_at,
+        )
 
     issues = await github.get_repo_issues(owner, repo_name)
     pull_requests = await github.get_repo_prs(owner, repo_name)
@@ -627,7 +812,8 @@ async def fetch_single_repo(
             if sonar_status:
                 break
 
-    local_path = github.get_local_repo_path(repo_name)
+    if local_path is None:
+        local_path = github.get_local_repo_path(repo_name)
 
     # Check git status if repo is local
     has_uncommitted = False
@@ -663,6 +849,14 @@ async def fetch_repo_details(
         repo: Repository to load details for
     """
     if repo.details_loaded:
+        return
+
+    if repo.owner == LOCAL_ONLY_OWNER:
+        # Local-only repos have no issues/PRs to fetch.
+        repo.issues = []
+        repo.pull_requests = []
+        repo.open_issues_count = 0
+        repo.details_loaded = True
         return
 
     github = GitHubClient(config)

--- a/tests/test_local_repos.py
+++ b/tests/test_local_repos.py
@@ -1,0 +1,289 @@
+"""Tests for local repo scanning and local-only repo synthesis."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repo_tui.config import Config
+from repo_tui.data import (
+    LOCAL_ONLY_OWNER,
+    LocalRepoScan,
+    fetch_all_repos,
+    fetch_repo_details,
+    fetch_single_repo,
+    parse_github_origin,
+    scan_local_repos,
+)
+from repo_tui.models import RepoOverview
+
+# ---------- parse_github_origin --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("git@github.com:adamkwhite/repo-tui.git", ("adamkwhite", "repo-tui")),
+        ("git@github.com:adamkwhite/repo-tui", ("adamkwhite", "repo-tui")),
+        ("https://github.com/adamkwhite/repo-tui.git", ("adamkwhite", "repo-tui")),
+        ("https://github.com/adamkwhite/repo-tui", ("adamkwhite", "repo-tui")),
+        ("https://github.com/adamkwhite/repo-tui/", ("adamkwhite", "repo-tui")),
+        ("http://github.com/adamkwhite/repo-tui.git", ("adamkwhite", "repo-tui")),
+        # Preserves case so we can present the canonical name back to users.
+        ("git@github.com:adamkwhite/KafkaFoodPipeline.git", ("adamkwhite", "KafkaFoodPipeline")),
+        # Token in URL.
+        (
+            "https://x-access-token:abc@github.com/adamkwhite/repo-tui.git",
+            ("adamkwhite", "repo-tui"),
+        ),
+    ],
+)
+def test_parse_github_origin_valid(url: str, expected: tuple[str, str]) -> None:
+    assert parse_github_origin(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not-a-url",
+        "git@gitlab.com:adamkwhite/repo-tui.git",
+        "https://bitbucket.org/adamkwhite/repo-tui.git",
+        "https://github.com/",
+        "https://example.com/adamkwhite/repo-tui.git",
+    ],
+)
+def test_parse_github_origin_rejects_non_github(url: str) -> None:
+    assert parse_github_origin(url) is None
+
+
+# ---------- scan_local_repos -----------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run a git command, swallowing output."""
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _make_repo(parent: Path, name: str, origin: str | None = None) -> Path:
+    """Create a real (tiny) git repo with optional origin remote."""
+    path = parent / name
+    path.mkdir()
+    _git(path, "init", "-q", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "README.md").write_text("hi")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-q", "-m", "init")
+    if origin:
+        _git(path, "remote", "add", "origin", origin)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_scan_local_repos_empty_dir(tmp_path: Path) -> None:
+    scan = await scan_local_repos(tmp_path)
+    assert scan.by_owner_repo == {}
+    assert scan.local_only == []
+
+
+@pytest.mark.asyncio
+async def test_scan_local_repos_missing_dir(tmp_path: Path) -> None:
+    scan = await scan_local_repos(tmp_path / "nope")
+    assert scan == LocalRepoScan(by_owner_repo={}, local_only=[])
+
+
+@pytest.mark.asyncio
+async def test_scan_local_repos_classifies_repos(tmp_path: Path) -> None:
+    # Mismatched-name local checkout (the original bug).
+    kafka = _make_repo(
+        tmp_path,
+        "kafka-food-pipeline",
+        origin="git@github.com:adamkwhite/KafkaFoodPipeline.git",
+    )
+    # Normal local checkout.
+    repo_tui = _make_repo(
+        tmp_path,
+        "repo-tui",
+        origin="https://github.com/adamkwhite/repo-tui.git",
+    )
+    # Truly local-only (no remote at all).
+    local_only = _make_repo(tmp_path, "flappy-bird", origin=None)
+    # Non-GitHub remote — treat like local-only since we can't surface PRs/issues.
+    gitlab_repo = _make_repo(
+        tmp_path,
+        "internal-tool",
+        origin="git@gitlab.com:team/internal-tool.git",
+    )
+    # A non-git directory that should be ignored.
+    (tmp_path / "not-a-repo").mkdir()
+    (tmp_path / "not-a-repo" / "file.txt").write_text("x")
+
+    scan = await scan_local_repos(tmp_path)
+
+    assert scan.by_owner_repo == {
+        ("adamkwhite", "kafkafoodpipeline"): kafka,
+        ("adamkwhite", "repo-tui"): repo_tui,
+    }
+    assert sorted(scan.local_only) == sorted([local_only, gitlab_repo])
+
+
+# ---------- fetch_all_repos integration ------------------------------------------
+
+
+def _config(local_path: Path, included: list[str] | None = None) -> Config:
+    """Build a Config pointing at a temp local code path."""
+    cfg_data = {
+        "included_repos": included or [],
+        "excluded_repos": [],
+        "local_code_path": str(local_path),
+        "friendly_names": {},
+    }
+    cfg_path = local_path / ".repo-overview.json"
+    cfg_path.write_text(json.dumps(cfg_data))
+    return Config(str(cfg_path))
+
+
+def _gh_repo(name: str, owner: str = "adamkwhite") -> dict:
+    """Build a fake `gh repo list` JSON entry."""
+    return {
+        "name": name,
+        "owner": {"login": owner},
+        "url": f"https://github.com/{owner}/{name}",
+        "hasIssuesEnabled": True,
+        "primaryLanguage": None,
+        "repositoryTopics": [],
+        "description": None,
+        "pushedAt": "2026-01-01T00:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_repos_matches_mismatched_local_dir(tmp_path: Path) -> None:
+    """Local dir 'kafka-food-pipeline' should be matched to remote 'KafkaFoodPipeline'."""
+    _make_repo(
+        tmp_path,
+        "kafka-food-pipeline",
+        origin="git@github.com:adamkwhite/KafkaFoodPipeline.git",
+    )
+    config = _config(tmp_path)
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues,
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+    ):
+        gh.return_value = [_gh_repo("KafkaFoodPipeline")]
+        issues.return_value = []
+        prs.return_value = []
+
+        result = await fetch_all_repos(config)
+
+    assert len(result.repos) == 1
+    repo = result.repos[0]
+    assert repo.name == "KafkaFoodPipeline"
+    assert repo.local_path == str(tmp_path / "kafka-food-pipeline")
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_repos_synthesizes_local_only_repos(tmp_path: Path) -> None:
+    _make_repo(tmp_path, "flappy-bird", origin=None)
+    config = _config(tmp_path)
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues,
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+        patch("repo_tui.data.save_cache"),
+    ):
+        gh.return_value = []
+        issues.return_value = []
+        prs.return_value = []
+
+        result = await fetch_all_repos(config)
+
+    assert len(result.repos) == 1
+    local = result.repos[0]
+    assert local.name == "flappy-bird"
+    assert local.owner == LOCAL_ONLY_OWNER
+    assert local.url == ""
+    assert local.local_path == str(tmp_path / "flappy-bird")
+    assert local.details_loaded is True
+    assert local.pushed_at is not None  # derived from last commit
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_repos_local_only_respects_included_filter(tmp_path: Path) -> None:
+    _make_repo(tmp_path, "flappy-bird", origin=None)
+    _make_repo(tmp_path, "menu-planner", origin=None)
+    # Whitelist mode: only show flappy-bird.
+    config = _config(tmp_path, included=["flappy-bird"])
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.save_cache"),
+    ):
+        gh.return_value = []
+        result = await fetch_all_repos(config)
+
+    names = [r.name for r in result.repos]
+    assert names == ["flappy-bird"]
+
+
+# ---------- fetch_single_repo / fetch_repo_details -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_single_repo_local_only_skips_github(tmp_path: Path) -> None:
+    path = _make_repo(tmp_path, "flappy-bird", origin=None)
+    config = _config(tmp_path)
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues,
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+    ):
+        repo = await fetch_single_repo(
+            config,
+            owner=LOCAL_ONLY_OWNER,
+            repo_name="flappy-bird",
+            local_path=path,
+        )
+
+    issues.assert_not_called()
+    prs.assert_not_called()
+    assert repo.owner == LOCAL_ONLY_OWNER
+    assert repo.local_path == str(path)
+    assert repo.url == ""
+    assert repo.details_loaded is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_repo_details_local_only_no_op() -> None:
+    config = Config.__new__(Config)  # bypass __init__
+    config.data = {}
+    repo = RepoOverview(
+        name="flappy-bird",
+        owner=LOCAL_ONLY_OWNER,
+        url="",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        local_path="/tmp/flappy-bird",
+        details_loaded=False,
+    )
+
+    with patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues:
+        await fetch_repo_details(config, repo)
+
+    issues.assert_not_called()
+    assert repo.details_loaded is True
+    assert repo.issues == []
+    assert repo.pull_requests == []


### PR DESCRIPTION
## Summary

Two related fixes for repo discovery:

1. **Surface local-only repos.** Git dirs in `local_code_path` with no GitHub remote (e.g. `flappy-bird`, `menu-planner`, `cdnquesport`) now appear alongside GitHub-backed repos. They use `owner="local"`, an empty `url`, and `pushed_at` derived from the last commit. Issues/PRs/Sonar are skipped.

2. **Match checkouts by remote URL, not directory name.** Previously `data.py` matched a local checkout to a GitHub repo by exact directory-name equality, so `~/Code/kafka-food-pipeline` never resolved to `adamkwhite/KafkaFoodPipeline`. Now we parse each dir's `origin` URL and key off `(owner, name)` from the remote.

## Changes

- `src/repo_tui/data.py`
  - `parse_github_origin(url)` — handles SSH and HTTPS GitHub URLs (with optional auth, optional `.git`, optional trailing slash); returns `None` for non-GitHub remotes.
  - `scan_local_repos(path)` — async parallel scan, returns `(by_owner_repo, local_only)`.
  - `_build_local_only_overviews()` — synthesizes `RepoOverview` entries for local-only dirs (respects `included_repos` / `excluded_repos`).
  - `fetch_all_repos`: scans once, replaces `github.get_local_repo_path(name)` with the URL-keyed lookup, and appends local-only entries before sort.
  - `fetch_single_repo`/`fetch_repo_details`: short-circuit for `owner == "local"` so refresh doesn't hit GitHub.
- `src/repo_tui/app.py`: refresh actions pass `local_path` through to `fetch_single_repo`.
- `tests/test_local_repos.py` (new): 22 cases covering URL parsing, scanning real temp git repos, classification, name-mismatch matching, local-only synthesis, filter respect, and the GitHub-call short-circuit.

## Verified live

Against `~/Code`: 30 → 39 repos.
- 6 new local-only entries: `flappy-bird`, `menu-planner`, `cdnquesport`, `cdnquesport-design-{a,b,c}`.
- 5 mismatched checkouts now correctly linked: `coaching-site`, `Virtual-Dietitian`, `KafkaFoodPipeline`, `project_template`, `rob_assignment`.

## Test plan

- [x] `./test.sh` — 44 passed (22 original + 22 new)
- [x] `ruff check`, `ruff format --check`, `mypy` — clean
- [x] Live smoke test against `~/Code` — confirmed local-only surfaced and name mismatches resolved
- [ ] Run the TUI manually and verify local-only entries render and that refresh on a local-only repo doesn't error

🤖 Generated with [Claude Code](https://claude.com/claude-code)