### PR TITLE
feat: add privacy mode to mask private repo details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,22 @@ The app supports two view modes (switch with `1` and `2` keys):
 
 Both views share the same data model and support all actions (refresh, open, launch Claude, etc.).
 
+## Privacy Mode
+
+Masks private repo names, descriptions, issue/PR titles, and PR bodies so demo videos don't reveal sensitive repo details. Public repos are never affected.
+
+**How to enable:**
+- `p` key at runtime (toggleable)
+- `--privacy` / `-p` CLI flag
+- `"privacy_mode": true` in config file
+
+**What gets masked:**
+- Repo names: first 2 and last 2 chars kept, middle replaced with `*` (e.g. `secret-repo` → `se*******po`)
+- Descriptions, issue titles, PR titles, PR bodies: each word replaced with `*` of matching length
+- Branch names in PR detail view
+
+**Architecture:** `RepoOverview.privacy_mode` is a class-level toggle. `safe_name` property returns the masked name. `display_name` uses `safe_name`. `redact_text()` handles body/title masking. `is_private` field is populated from GitHub's `isPrivate` API field.
+
 ## Development & Testing
 
 ### Running the App

--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -7,7 +7,7 @@ import atexit
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from textual import events
 from textual.app import App, ComposeResult
@@ -20,12 +20,9 @@ from .config import Config
 from .data import fetch_all_repos, fetch_single_repo, format_cache_age
 from .dependabot import MergeResult, merge_all_dependabot_prs
 from .launcher import launch_claude
-from .models import Issue, PullRequest
+from .models import Issue, PullRequest, RepoOverview, redact_text
 from .widgets.repo_grid import RepoGridWidget
 from .widgets.repo_list import RepoListWidget
-
-if TYPE_CHECKING:
-    from .models import RepoOverview
 
 
 def _cleanup_terminal():
@@ -63,6 +60,7 @@ HELP_TEXT = """
   R             Refresh all repos
   s             Check SonarCloud for current repo
   S             Toggle SonarCloud for all repos
+  p             Toggle privacy mode (mask private repo names)
   D             Bulk-merge Dependabot PRs across all repos
   q             Quit
   ?             Show this help
@@ -205,12 +203,14 @@ class IssueDetailScreen(ModalScreen[int]):
         repo_name: str = "",
         issue_list: list[Issue] | None = None,
         current_index: int = 0,
+        is_private: bool = False,
     ) -> None:
         super().__init__()
         self.issue = issue
         self.repo_name = repo_name
         self.issue_list = issue_list or []
         self.current_index = current_index
+        self.is_private = is_private
 
     def compose(self) -> ComposeResult:
         with Vertical(id="issue-detail-container"):
@@ -280,6 +280,12 @@ class IssueDetailScreen(ModalScreen[int]):
             self.issue = self.issue_list[new_index]
             self._update_content()
 
+    def _redact(self, text: str) -> str:
+        """Redact text if this repo is private and privacy mode is on."""
+        if RepoOverview.privacy_mode and self.is_private:
+            return redact_text(text)
+        return text
+
     def _update_content(self) -> None:
         """Update all content for current issue."""
         issue = self.issue
@@ -287,7 +293,7 @@ class IssueDetailScreen(ModalScreen[int]):
         # Title
         title_text = (
             f"[bold]{self.repo_name}[/bold] "
-            f"[cyan]#{issue.number}[/cyan] {self._escape(issue.title)}"
+            f"[cyan]#{issue.number}[/cyan] {self._escape(self._redact(issue.title))}"
         )
         self.query_one("#issue-title", Static).update(title_text)
 
@@ -309,7 +315,7 @@ class IssueDetailScreen(ModalScreen[int]):
 
         # Body
         body = issue.body or "[dim]No description provided[/dim]"
-        self.query_one("#issue-body", Static).update(self._escape(body))
+        self.query_one("#issue-body", Static).update(self._escape(self._redact(body)))
 
         # Reset scroll position
         self.query_one("#issue-body-scroll", VerticalScroll).scroll_home()
@@ -390,10 +396,12 @@ class PRDetailScreen(ModalScreen[int]):
         repo_name: str = "",
         pr_list: list[PullRequest] | None = None,
         current_index: int = 0,
+        is_private: bool = False,
     ) -> None:
         super().__init__()
         self.pr = pr
         self.repo_name = repo_name
+        self.is_private = is_private
         self.pr_list = pr_list or []
         self.current_index = current_index
 
@@ -446,6 +454,12 @@ class PRDetailScreen(ModalScreen[int]):
             self.pr = self.pr_list[new_index]
             self._update_content()
 
+    def _redact(self, text: str) -> str:
+        """Redact text if this repo is private and privacy mode is on."""
+        if RepoOverview.privacy_mode and self.is_private:
+            return redact_text(text)
+        return text
+
     def _update_content(self) -> None:
         """Update all content for current PR."""
         pr = self.pr
@@ -454,7 +468,7 @@ class PRDetailScreen(ModalScreen[int]):
         draft_badge = "[yellow]DRAFT[/yellow] " if pr.draft else ""
         title_text = (
             f"[bold]{self.repo_name}[/bold] "
-            f"[green]PR #{pr.number}[/green] {draft_badge}{self._escape(pr.title)}"
+            f"[green]PR #{pr.number}[/green] {draft_badge}{self._escape(self._redact(pr.title))}"
         )
         self.query_one("#pr-title", Static).update(title_text)
 
@@ -477,7 +491,9 @@ class PRDetailScreen(ModalScreen[int]):
 
         # Branch info
         if pr.head_ref and pr.base_ref:
-            status_parts.append(f"[cyan]{pr.head_ref}[/cyan] → [cyan]{pr.base_ref}[/cyan]")
+            head = self._redact(pr.head_ref)
+            base = self._redact(pr.base_ref)
+            status_parts.append(f"[cyan]{head}[/cyan] → [cyan]{base}[/cyan]")
 
         # Review decision
         if pr.review_decision == "APPROVED":
@@ -517,7 +533,7 @@ class PRDetailScreen(ModalScreen[int]):
 
         # Body/description
         body_text = pr.body if pr.body else "[dim]No description provided[/dim]"
-        self.query_one("#pr-body", Static).update(body_text)
+        self.query_one("#pr-body", Static).update(self._redact(body_text))
 
     def _escape(self, text: str) -> str:
         """Escape Rich markup characters in text."""
@@ -751,6 +767,7 @@ class RepoOverviewApp(App[None]):
         Binding("c", "launch", "Claude"),
         Binding("s", "sonar_repo", "Sonar"),
         Binding("S", "sonar_all", "Sonar All"),
+        Binding("p", "toggle_privacy", "Privacy"),
         Binding("D", "merge_dependabot", "Merge Dependabot"),
         Binding("question_mark", "help", "Help"),
         Binding("space", "toggle_expand", "Expand"),
@@ -766,13 +783,14 @@ class RepoOverviewApp(App[None]):
         Binding("right", "cursor_right", "Right", show=False),
     ]
 
-    def __init__(self, check_sonar: bool = False) -> None:
+    def __init__(self, check_sonar: bool = False, privacy: bool = False) -> None:
         super().__init__()
         self.config = Config()
         self.repos: list[RepoOverview] = []
         self.check_sonar = check_sonar
         self.view_mode = "list"  # "list" or "grid"
         self.is_cached = False
+        RepoOverview.privacy_mode = privacy or self.config.data.get("privacy_mode", False)
 
     def compose(self) -> ComposeResult:
         """Create the UI layout."""
@@ -880,6 +898,15 @@ class RepoOverviewApp(App[None]):
             # Widget might not exist during transition
             return None
 
+    async def action_toggle_privacy(self) -> None:
+        """Toggle privacy mode (mask private repo names)."""
+        RepoOverview.privacy_mode = not RepoOverview.privacy_mode
+        current_widget = self._get_current_widget()
+        if current_widget:
+            current_widget.set_repos(self.repos)
+        status = "ON" if RepoOverview.privacy_mode else "OFF"
+        self.query_one(StatusBar).update(f"Privacy mode {status}")
+
     async def action_switch_view_list(self) -> None:
         """Switch to list view."""
         if self.view_mode != "list":
@@ -919,7 +946,7 @@ class RepoOverviewApp(App[None]):
             )
             return
 
-        loading_screen = LoadingScreen(f"Refreshing {selected_repo.name}...")
+        loading_screen = LoadingScreen(f"Refreshing {selected_repo.safe_name}...")
         self.push_screen(loading_screen)
 
         await asyncio.sleep(0.1)
@@ -931,6 +958,7 @@ class RepoOverviewApp(App[None]):
                 selected_repo.name,
                 self.check_sonar,
                 local_path=Path(selected_repo.local_path) if selected_repo.local_path else None,
+                is_private=selected_repo.is_private,
             )
 
             # Replace the repo in our list
@@ -948,7 +976,9 @@ class RepoOverviewApp(App[None]):
             total_issues = sum(r.open_issues_count for r in self.repos)
             sonar_indicator = " [SonarCloud ON]" if self.check_sonar else ""
             status_bar.update_stats(
-                len(self.repos), total_issues, f"Refreshed {selected_repo.name}{sonar_indicator}"
+                len(self.repos),
+                total_issues,
+                f"Refreshed {selected_repo.safe_name}{sonar_indicator}",
             )
         finally:
             self.pop_screen()
@@ -977,7 +1007,7 @@ class RepoOverviewApp(App[None]):
             )
             return
 
-        loading_screen = LoadingScreen(f"Checking Sonar for {selected_repo.name}...")
+        loading_screen = LoadingScreen(f"Checking Sonar for {selected_repo.safe_name}...")
         self.push_screen(loading_screen)
 
         await asyncio.sleep(0.1)
@@ -989,6 +1019,7 @@ class RepoOverviewApp(App[None]):
                 selected_repo.name,
                 check_sonar=True,
                 local_path=Path(selected_repo.local_path) if selected_repo.local_path else None,
+                is_private=selected_repo.is_private,
             )
 
             # Replace the repo in our list
@@ -1003,7 +1034,7 @@ class RepoOverviewApp(App[None]):
 
             total_issues = sum(r.open_issues_count for r in self.repos)
             status_bar.update_stats(
-                len(self.repos), total_issues, f"Sonar checked: {selected_repo.name}"
+                len(self.repos), total_issues, f"Sonar checked: {selected_repo.safe_name}"
             )
         finally:
             self.pop_screen()
@@ -1022,7 +1053,7 @@ class RepoOverviewApp(App[None]):
 
             total = len(self.repos)
             for i, repo in enumerate(self.repos):
-                loading_screen.update_message(f"Checking {i + 1}/{total}", repo.name)
+                loading_screen.update_message(f"Checking {i + 1}/{total}", repo.safe_name)
 
                 # Try to find sonar project
                 project_keys = sonar.guess_project_key(repo.owner, repo.name)
@@ -1059,7 +1090,7 @@ class RepoOverviewApp(App[None]):
             return
 
         if not selected_repo.local_path:
-            status_bar.update(f"Repo not found locally: ~/Code/{selected_repo.name}")
+            status_bar.update(f"Repo not found locally: ~/Code/{selected_repo.safe_name}")
             return
 
         # Check if an inline PR is selected
@@ -1076,7 +1107,7 @@ class RepoOverviewApp(App[None]):
         elif selected_issue:
             msg = f"Launching #{selected_issue.number}..."
         else:
-            msg = f"Launching {selected_repo.name}..."
+            msg = f"Launching {selected_repo.safe_name}..."
 
         loading_screen = LoadingScreen(msg)
         await self.push_screen(loading_screen)
@@ -1186,7 +1217,9 @@ class RepoOverviewApp(App[None]):
                 0,
             )
             await self.push_screen(
-                PRDetailScreen(pr, repo.name, pr_list, current_index),
+                PRDetailScreen(
+                    pr, repo.safe_name, pr_list, current_index, is_private=repo.is_private
+                ),
                 callback=self._on_pr_detail_dismiss,
             )
             return
@@ -1201,7 +1234,9 @@ class RepoOverviewApp(App[None]):
                 0,
             )
             await self.push_screen(
-                IssueDetailScreen(issue, repo.name, issue_list, current_index),
+                IssueDetailScreen(
+                    issue, repo.safe_name, issue_list, current_index, is_private=repo.is_private
+                ),
                 callback=self._on_issue_detail_dismiss,
             )
             return
@@ -1216,12 +1251,24 @@ class RepoOverviewApp(App[None]):
                 # Already expanded, show first PR or issue
                 if repo.pull_requests:
                     await self.push_screen(
-                        PRDetailScreen(repo.pull_requests[0], repo.name, repo.pull_requests, 0),
+                        PRDetailScreen(
+                            repo.pull_requests[0],
+                            repo.safe_name,
+                            repo.pull_requests,
+                            0,
+                            is_private=repo.is_private,
+                        ),
                         callback=self._on_pr_detail_dismiss,
                     )
                 elif repo.issues:
                     await self.push_screen(
-                        IssueDetailScreen(repo.issues[0], repo.name, repo.issues, 0),
+                        IssueDetailScreen(
+                            repo.issues[0],
+                            repo.safe_name,
+                            repo.issues,
+                            0,
+                            is_private=repo.is_private,
+                        ),
                         callback=self._on_issue_detail_dismiss,
                     )
 
@@ -1263,9 +1310,12 @@ def main() -> None:
     parser.add_argument(
         "-s", "--sonar", action="store_true", help="Check SonarCloud/SonarQube status on startup"
     )
+    parser.add_argument(
+        "-p", "--privacy", action="store_true", help="Enable privacy mode (mask private repo names)"
+    )
     args = parser.parse_args()
 
-    app = RepoOverviewApp(check_sonar=args.sonar)
+    app = RepoOverviewApp(check_sonar=args.sonar, privacy=args.privacy)
     app.run()
 
 

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -89,6 +89,7 @@ def _dict_to_repo(d: dict) -> RepoOverview:
         open_issues_count=d["open_issues_count"],
         issues=issues,
         sonar_status=sonar,
+        is_private=d.get("is_private", False),
         local_path=d.get("local_path"),
         sonar_checked=d.get("sonar_checked", False),
         language=d.get("language"),
@@ -228,7 +229,7 @@ class GitHubClient:
             cmd.extend(
                 [
                     "--json",
-                    "name,owner,url,hasIssuesEnabled,primaryLanguage,repositoryTopics,description,pushedAt",
+                    "name,owner,url,hasIssuesEnabled,primaryLanguage,repositoryTopics,description,pushedAt,isPrivate",
                     "--limit",
                     "1000",
                 ]
@@ -718,6 +719,7 @@ async def fetch_all_repos(
             open_issues_count=len(issues),
             issues=issues,
             sonar_status=sonar_status,
+            is_private=repo_data.get("isPrivate", False),
             local_path=str(local_path) if local_path else None,
             sonar_checked=sonar_checked,
             language=language,
@@ -761,6 +763,7 @@ async def fetch_single_repo(
     repo_name: str,
     check_sonar: bool = False,
     local_path: Path | None = None,
+    is_private: bool = False,
 ) -> RepoOverview:
     """Fetch data for a single repository.
 
@@ -791,6 +794,7 @@ async def fetch_single_repo(
             open_issues_count=0,
             issues=[],
             sonar_status=None,
+            is_private=is_private,
             local_path=str(path) if path else None,
             sonar_checked=False,
             pull_requests=[],
@@ -828,6 +832,7 @@ async def fetch_single_repo(
         open_issues_count=len(issues),
         issues=issues,
         sonar_status=sonar_status,
+        is_private=is_private,
         local_path=str(local_path) if local_path else None,
         sonar_checked=check_sonar,
         pull_requests=pull_requests,

--- a/src/repo_tui/launcher.py
+++ b/src/repo_tui/launcher.py
@@ -88,7 +88,7 @@ def launch_claude(
     Returns a status message.
     """
     if not repo.local_path:
-        return f"Repo not found locally: ~/Code/{repo.name}"
+        return f"Repo not found locally: ~/Code/{repo.safe_name}"
 
     try:
         # Get claude command from config, default to "claude"
@@ -114,10 +114,10 @@ def launch_claude(
         )
 
         if pr:
-            return f"Launched Claude for {repo.name} PR #{pr.number}"
+            return f"Launched Claude for {repo.safe_name} PR #{pr.number}"
         if issue:
-            return f"Launched Claude for {repo.name} #{issue.number}"
-        return f"Launched Claude for {repo.name}"
+            return f"Launched Claude for {repo.safe_name} #{issue.number}"
+        return f"Launched Claude for {repo.safe_name}"
 
     except FileNotFoundError as e:
         error_msg = f"Error: File not found - {e.filename}"

--- a/src/repo_tui/models.py
+++ b/src/repo_tui/models.py
@@ -56,9 +56,25 @@ class SonarStatus:
 CLOUD_TOPICS = {"aws", "azure", "gcp", "cloudflare", "vercel", "heroku", "digitalocean"}
 
 
+def mask_name(name: str) -> str:
+    """Mask the middle of a name with asterisks, keeping first 2 and last 2 chars."""
+    if len(name) <= 4:
+        return "*" * len(name)
+    return name[:2] + "*" * (len(name) - 4) + name[-2:]
+
+
+def redact_text(text: str) -> str:
+    """Replace each word with asterisks of matching length, preserving whitespace and punctuation."""
+    import re
+
+    return re.sub(r"\w+", lambda m: "*" * len(m.group()), text)
+
+
 @dataclass
 class RepoOverview:
     """Repository overview with issues and SonarCloud status."""
+
+    privacy_mode = False
 
     name: str
     owner: str
@@ -66,17 +82,18 @@ class RepoOverview:
     open_issues_count: int
     issues: list[Issue]
     sonar_status: SonarStatus | None
+    is_private: bool = False
     local_path: str | None = None
-    sonar_checked: bool = False  # True if we attempted to check SonarCloud
-    language: str | None = None  # Primary programming language
-    topics: list[str] | None = None  # Repository topics/tags
-    pull_requests: list[PullRequest] | None = None  # Open pull requests
-    details_loaded: bool = False  # True if issues/PRs have been fetched
-    has_uncommitted_changes: bool = False  # True if local repo has uncommitted changes
-    current_branch: str | None = None  # Current git branch if local repo exists
-    description: str | None = None  # Repository description
-    friendly_name: str | None = None  # User-configured friendly display name
-    pushed_at: str | None = None  # Last push date (ISO 8601)
+    sonar_checked: bool = False
+    language: str | None = None
+    topics: list[str] | None = None
+    pull_requests: list[PullRequest] | None = None
+    details_loaded: bool = False
+    has_uncommitted_changes: bool = False
+    current_branch: str | None = None
+    description: str | None = None
+    friendly_name: str | None = None
+    pushed_at: str | None = None
 
     @property
     def pushed_at_relative(self) -> str | None:
@@ -106,11 +123,24 @@ class RepoOverview:
             return None
 
     @property
+    def safe_name(self) -> str:
+        """Repo name masked if private and privacy mode is on."""
+        if RepoOverview.privacy_mode and self.is_private:
+            return mask_name(self.name)
+        return self.name
+
+    @property
     def display_name(self) -> str:
         """Get the display name (friendly name if set, otherwise repo name)."""
+        name = self.safe_name
         if self.friendly_name:
-            return f"{self.friendly_name} [dim]({self.name})[/dim]"
-        return self.name
+            friendly = (
+                mask_name(self.friendly_name)
+                if (RepoOverview.privacy_mode and self.is_private)
+                else self.friendly_name
+            )
+            return f"{friendly} [dim]({name})[/dim]"
+        return name
 
     @property
     def critical_issue_count(self) -> int:

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -10,8 +10,10 @@ from textual.message import Message
 from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
+from ..models import RepoOverview, redact_text
+
 if TYPE_CHECKING:
-    from ..models import Issue, PullRequest, RepoOverview
+    from ..models import Issue, PullRequest
 
 
 SPECIAL_ACTION_DEPENDABOT = "dependabot-merge"
@@ -174,7 +176,12 @@ class RepoListWidget(OptionList):
 
     def _build_issue_option(self, repo: RepoOverview, issue: Issue) -> Option:
         """Build a rich option for an issue (indented under repo)."""
-        text = Text.from_markup(f"    [dim]#{issue.number}[/dim] {issue.title}")
+        title = (
+            redact_text(issue.title)
+            if (RepoOverview.privacy_mode and repo.is_private)
+            else issue.title
+        )
+        text = Text.from_markup(f"    [dim]#{issue.number}[/dim] {title}")
         return Option(text, id=f"issue:{repo.name}:{issue.number}")
 
     def _build_pr_option(self, repo: RepoOverview, pr: PullRequest) -> Option:
@@ -212,14 +219,18 @@ class RepoListWidget(OptionList):
         # Prefer full name over username
         display_name = pr.author_name if pr.author_name else pr.author
         author = f"[dim]by {display_name}[/dim] " if display_name else ""
+        _private = RepoOverview.privacy_mode and repo.is_private
+        title = redact_text(pr.title) if _private else pr.title
         text = Text.from_markup(
-            f"    [green]PR #{pr.number}[/green] {draft}{date_str}{author}{pr.title}"
+            f"    [green]PR #{pr.number}[/green] {draft}{date_str}{author}{title}"
         )
         return Option(text, id=f"pr:{repo.name}:{pr.number}")
 
     def _build_description_option(self, repo: RepoOverview) -> Option:
         """Build a rich option for the repo description."""
         desc = repo.description if repo.description else "No description"
+        if RepoOverview.privacy_mode and repo.is_private:
+            desc = redact_text(desc)
         text = Text.from_markup(f"    [white italic]{desc}[/white italic]")
         return Option(text, id=f"desc:{repo.name}", disabled=True)
 

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,52 @@
+"""Tests for privacy-mode masking (models.mask_name / redact_text / safe_name)."""
+
+import pytest
+
+from repo_tui.models import RepoOverview, mask_name, redact_text
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy():
+    """Privacy mode is a class-level toggle; keep tests isolated."""
+    original = RepoOverview.privacy_mode
+    yield
+    RepoOverview.privacy_mode = original
+
+
+def test_mask_name_keeps_first_and_last_two():
+    assert mask_name("secret-repo") == "se*******po"
+
+
+def test_mask_name_short_names_fully_masked():
+    # <= 4 chars have no safe middle to reveal
+    assert mask_name("api") == "***"
+    assert mask_name("abcd") == "****"
+
+
+def test_redact_text_masks_words_preserves_punctuation():
+    assert redact_text("Fix login bug!") == "*** ***** ***!"
+
+
+def _repo(name="my-repo", is_private=False):
+    return RepoOverview(
+        name=name,
+        owner="me",
+        url="https://example.com",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        is_private=is_private,
+    )
+
+
+def test_public_repo_never_masked_even_with_privacy_on():
+    RepoOverview.privacy_mode = True
+    assert _repo("public-repo", is_private=False).safe_name == "public-repo"
+
+
+def test_private_repo_masked_only_when_privacy_on():
+    private = _repo("secret-repo", is_private=True)
+    RepoOverview.privacy_mode = False
+    assert private.safe_name == "secret-repo"
+    RepoOverview.privacy_mode = True
+    assert private.safe_name == "se*******po"


### PR DESCRIPTION
## Summary
Adds a **privacy mode** that masks private repo names, descriptions, and issue/PR titles/bodies so demo videos / screen-shares don't leak sensitive repo details. Public repos are never affected.

Split out of the gitleaks-hook branch (#44) where this feature had been sitting uncommitted — one logical change per PR.

## How to enable
- `p` key at runtime (toggle)
- `--privacy` / `-p` CLI flag
- `"privacy_mode": true` in `~/.repo-overview.json`

## What gets masked (private repos only)
- **Repo names**: first 2 + last 2 chars kept (`secret-repo` → `se*******po`)
- **Descriptions, issue/PR titles, PR bodies**: each word → `*` of matching length
- Branch names in PR detail view

## Implementation
- `mask_name()` / `redact_text()` helpers + `safe_name` property on `RepoOverview`
- `is_private` populated from GitHub's `isPrivate` field
- Class-level `privacy_mode` toggle wired through app, list, grid, launcher

## Tests
`tests/test_privacy.py` covers the security-relevant contract: public repos never masked, private masked only when the toggle is on. All 49 tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)