### PR TITLE
fix(repo-list): escape markup in issue/PR titles and descriptions

### DIFF
--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC
 from typing import TYPE_CHECKING
 
+from rich.markup import escape
 from rich.text import Text
 from textual.message import Message
 from textual.widgets import OptionList
@@ -181,7 +182,7 @@ class RepoListWidget(OptionList):
             if (RepoOverview.privacy_mode and repo.is_private)
             else issue.title
         )
-        text = Text.from_markup(f"    [dim]#{issue.number}[/dim] {title}")
+        text = Text.from_markup(f"    [dim]#{issue.number}[/dim] {escape(title)}")
         return Option(text, id=f"issue:{repo.name}:{issue.number}")
 
     def _build_pr_option(self, repo: RepoOverview, pr: PullRequest) -> Option:
@@ -222,7 +223,7 @@ class RepoListWidget(OptionList):
         _private = RepoOverview.privacy_mode and repo.is_private
         title = redact_text(pr.title) if _private else pr.title
         text = Text.from_markup(
-            f"    [green]PR #{pr.number}[/green] {draft}{date_str}{author}{title}"
+            f"    [green]PR #{pr.number}[/green] {draft}{date_str}{author}{escape(title)}"
         )
         return Option(text, id=f"pr:{repo.name}:{pr.number}")
 
@@ -231,7 +232,7 @@ class RepoListWidget(OptionList):
         desc = repo.description if repo.description else "No description"
         if RepoOverview.privacy_mode and repo.is_private:
             desc = redact_text(desc)
-        text = Text.from_markup(f"    [white italic]{desc}[/white italic]")
+        text = Text.from_markup(f"    [white italic]{escape(desc)}[/white italic]")
         return Option(text, id=f"desc:{repo.name}", disabled=True)
 
     def toggle_expand(self) -> None:

--- a/tests/test_repo_list_widget.py
+++ b/tests/test_repo_list_widget.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from rich.console import Console
+from rich.text import Text
 
 from repo_tui.app import DependabotMergeScreen, RepoOverviewApp
-from repo_tui.models import RepoOverview
+from repo_tui.models import Issue, PullRequest, RepoOverview
 from repo_tui.widgets.repo_list import RepoListWidget
 
 
@@ -108,3 +110,54 @@ async def test_dependabot_modal_copy_skips_when_empty():
         screen.action_copy_log()
 
         fake_clipboard.assert_not_called()
+
+
+def _resolve_styles(text: Text) -> None:
+    """Force Rich to resolve every span style, mirroring Textual's render path.
+
+    Textual calls ``console.get_style(span.style)`` when it visualizes an Option;
+    a bracketed field like a ``[ops-triage]`` issue title, if fed to
+    ``Text.from_markup`` unescaped, becomes a span with an unparseable style name
+    and raises ``MissingStyle``. This helper reproduces that resolution.
+    """
+    console = Console()
+    for span in text.spans:
+        if isinstance(span.style, str):
+            console.get_style(span.style)
+
+
+def test_bracketed_titles_are_escaped_not_treated_as_markup():
+    """Issue/PR titles and descriptions containing [...] must not crash rendering."""
+    widget = RepoListWidget()
+    repo = _repo("job-agent")
+
+    issue = Issue(
+        number=2121,
+        title="[ops-triage] supra_newsletter: no_input for 296h (0 jobs/7d)",
+        url="u",
+        labels=["ops-triage"],
+        state="OPEN",
+        body="",
+        assignee=None,
+    )
+    _resolve_styles(widget._build_issue_option(repo, issue).prompt)
+
+    pr = PullRequest(
+        number=1,
+        title="feat: add [beta] flag",
+        url="u",
+        author="x",
+        state="OPEN",
+        draft=False,
+        labels=[],
+        body="",
+        head_ref="h",
+        base_ref="main",
+    )
+    _resolve_styles(widget._build_pr_option(repo, pr).prompt)
+
+    repo.description = "supports [Claude] and [GPT]"
+    opt = widget._build_description_option(repo)
+    _resolve_styles(opt.prompt)
+    # The bracketed text survives literally in the visible output.
+    assert "[Claude]" in opt.prompt.plain


### PR DESCRIPTION
## Problem

`./run.sh` crashed with `MissingStyle: Failed to get style 'ops-triage'` when expanding a repo whose issue title started with a bracketed token, e.g. the job-agent issue `[ops-triage] supra_newsletter: no_input for 296h (0 jobs/7d)`.

Root cause: issue titles, PR titles, and repo descriptions were interpolated directly into `Text.from_markup()`. Rich parsed the leading `[ops-triage]` as a markup tag opening an unknown style named `ops-triage`, producing a span that crashed when Textual resolved it via `console.get_style()` during option-list rendering.

## Fix

Escape those three free-text fields with `rich.markup.escape()` before they reach `from_markup`, so brackets render as literal text. GitHub repo names and git branch names cannot contain `[`, so the other interpolated fields are unaffected — this covers the whole bracket-injection surface.

## Tests

- Added `test_bracketed_titles_are_escaped_not_treated_as_markup`, which resolves span styles the same way Textual does. It reproduces the exact `MissingStyle` crash on the unescaped code and passes with the fix.
- Full suite: 50 passed. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQsoyKCPu9gfSJG4xmG6Am
