### PR TITLE
fix(launcher): update default Claude prompt to renamed /StartSession skill

### DIFF
--- a/src/repo_tui/launcher.py
+++ b/src/repo_tui/launcher.py
@@ -29,7 +29,7 @@ def build_claude_prompt(issue: Issue | None = None, pr: PullRequest | None = Non
         return f"Work on PR #{pr.number}{draft_status}: {pr.title}"
     if issue:
         return f"Work on issue #{issue.number}: {issue.title}"
-    return "/StartOfTheDay"
+    return "/StartSession"
 
 
 def build_wt_command(

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,41 @@
+"""Tests for the Claude Code launcher prompt building."""
+
+from __future__ import annotations
+
+from repo_tui.launcher import build_claude_prompt
+from repo_tui.models import Issue, PullRequest
+
+
+def test_default_prompt_uses_current_session_skill():
+    # No issue/PR selected -> launch the start-of-session skill.
+    # Pinned so a skill rename doesn't silently ship a dead slash-command again.
+    assert build_claude_prompt() == "/StartSession"
+
+
+def test_issue_prompt():
+    issue = Issue(
+        number=42,
+        title="Fix the thing",
+        url="u",
+        labels=[],
+        state="OPEN",
+        body="",
+        assignee=None,
+    )
+    assert build_claude_prompt(issue=issue) == "Work on issue #42: Fix the thing"
+
+
+def test_pr_prompt_marks_draft():
+    pr = PullRequest(
+        number=7,
+        title="Add feature",
+        url="u",
+        author="x",
+        state="OPEN",
+        draft=True,
+        labels=[],
+        body="",
+        head_ref="h",
+        base_ref="main",
+    )
+    assert build_claude_prompt(pr=pr) == "Work on PR #7 (DRAFT): Add feature"


### PR DESCRIPTION
## Problem

The `c` (launch Claude) action, when no issue or PR is selected, launched Claude Code with the prompt `/StartOfTheDay`. That skill no longer exists — it was renamed to `/StartSession` — so the launch fired a dead slash-command.

## Fix

`build_claude_prompt()` now returns `/StartSession`. Added `tests/test_launcher.py` pinning all three branches (default / issue / PR) so a future skill rename can't silently ship a dead command again.

## Tests

Full suite: 53 passed. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQsoyKCPu9gfSJG4xmG6Am