### PR TITLE
docs(readme): sync keybindings, views, and flags with actual code

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Or use JSON format (`~/.repo-overview.json`):
 
 ### Example Configurations
 
-**Personal repos:**
+**Personal repos, no SonarCloud:**
 ```yaml
 included_repos: []
 excluded_repos:
@@ -187,6 +187,48 @@ excluded_repos:
 sonarcloud_org: null
 github_org: null
 local_code_path: ~/Code
+```
+
+**Personal repos with SonarCloud:**
+
+When you sign into SonarCloud with GitHub, your personal organization key is your
+GitHub username. Both values below are the same string for that reason. Run with
+`./run.sh -s` to actually check quality gates.
+
+```yaml
+included_repos:
+  - invoice-parser
+  - trailhead-api
+  - dotfiles
+excluded_repos: []
+
+# SonarCloud org key — https://sonarcloud.io/organizations/jrivera-dev
+sonarcloud_org: jrivera-dev
+
+# Leave null for personal repos; `gh repo list` already scopes to your account.
+github_org: null
+
+local_code_path: ~/Code
+```
+
+**Organization repos with self-hosted SonarQube:**
+
+```yaml
+included_repos:
+  - billing-service
+  - customer-api
+excluded_repos: []
+
+# Bound to the GitHub org, so the keys match.
+github_org: northwind-labs
+sonarcloud_org: northwind-labs
+
+# Self-hosted instance instead of sonarcloud.io. `sonar_token_pass` is a path
+# in the `pass` password store, not the token itself: `pass insert work/sonarqube`
+sonar_url: https://sonarqube.northwind-labs.io
+sonar_token_pass: work/sonarqube
+
+local_code_path: ~/work/northwind
 ```
 
 **Organization repos (grouped by feature with comments):**

--- a/README.md
+++ b/README.md
@@ -5,15 +5,19 @@ Terminal UI for GitHub repository overview with SonarCloud integration.
 ## Features
 
 - **Repository List** - View all your GitHub repos with status indicators
-  - Red: Failed SonarCloud quality gate or 10+ open issues
-  - Yellow: Warning quality gate or 5+ issues
-  - Blue: 1-4 open issues
-  - Green: No issues
+  - Red: Failed SonarCloud quality gate (ERROR) or 5+ critical issues
+  - Yellow: Warning quality gate, uncommitted changes, or 1-4 critical issues
+  - Blue: Open pull requests
+  - Green: Clean
+- **Two Views** - List view (`1`) and 3-column grid view (`2`)
 - **Expandable Issues** - Press `Space` to expand inline issues under a repo
 - **Issue Details** - Press `e` to view full issue details in a modal
 - **Claude Code Integration** - Press `c` to launch Claude Code in a new Windows Terminal tab
+- **Dependabot Bulk Merge** - Press `D` to merge Dependabot PRs across all repos
 - **Quick Links** - Press `o` to open repo/issue in browser
 - **Privacy Mode** - Press `p` (or pass `--privacy`) to mask private repo names, descriptions, and issue/PR titles for screen-shares and demos (public repos are never masked)
+
+Critical issue labels: `bug`, `security`, `breaking-change`, `ci-failure`, `priority-high`, `status-blocked`.
 
 ## Requirements
 
@@ -51,23 +55,33 @@ python -m repo_tui.app
 
 # Development mode with hot reload
 ./dev.sh
+
+# Safe mode - guaranteed terminal cleanup on exit (see Troubleshooting)
+./run-safe.sh
 ```
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `-s`, `--sonar` | Check SonarCloud/SonarQube status on startup |
+| `-p`, `--privacy` | Start with privacy mode enabled |
 
 ## Keybindings
 
 | Key | Action |
 |-----|--------|
-| `j/↓` | Move down |
-| `k/↑` | Move up |
-| `Tab` | Switch between repo list and issue list |
+| `j/↓` `k/↑` | Move down / up |
+| `h/←` `l/→` | Move left / right (grid view) |
+| `1` / `2` | Switch to list view / grid view |
 | `Space` | Expand/collapse repo issues |
 | `e` | View issue details |
-| `h/l` | Navigate issues in modal |
 | `o` | Open in browser |
 | `c` | Launch Claude Code |
-| `r` | Refresh data |
-| `s` | Toggle SonarCloud check |
+| `r` / `R` | Refresh current repo / all repos |
+| `s` / `S` | Check SonarCloud for current repo / all repos |
 | `p` | Toggle privacy mode (mask private repo details) |
+| `D` | Bulk-merge Dependabot PRs across all repos |
 | `?` | Help |
 | `q` | Quit |
 
@@ -200,6 +214,26 @@ excluded_repos: []
 sonarcloud_org: my-company
 github_org: my-company
 local_code_path: ~/work/projects
+```
+
+## Development
+
+```bash
+pip install -r requirements-dev.txt
+
+./test.sh                       # Run all tests
+./test.sh tests/test_app.py -v  # Run a single test file
+make lint                       # ruff + mypy (see Makefile for all targets)
+```
+
+## Troubleshooting
+
+**Mouse codes appear in the terminal after exit** (e.g. `?2048;0$y`) - Textual's mouse
+tracking escape codes can outlive the process. Use `./run-safe.sh`, which traps exit and
+resets the terminal. To fix an already-corrupted session:
+
+```bash
+printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?25h'
 ```
 
 ## License

--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -50,7 +50,6 @@ HELP_TEXT = """
   Space         Expand/collapse repo issues
   1             Switch to list view
   2             Switch to grid view
-  3             Switch to Jira view (if configured)
 
 [cyan]Actions[/cyan]
   c             Launch Claude Code


### PR DESCRIPTION
## Summary

README had drifted from the implementation. Audited every documented claim against the code and fixed the mismatches.

**Wrong:**
- `Tab` binding — does not exist anywhere in the code
- `h/l` described as modal-only issue nav; they are global `cursor_left`/`cursor_right` (grid nav)
- Status-dot semantics ("10+ open issues" etc.) did not match `_build_repo_option` in `src/repo_tui/widgets/repo_list.py:96`
- `r`/`s` are per-repo; `R`/`S` (refresh-all, sonar-all) were undocumented

**Missing:**
- Grid view (`1`/`2`), documented in CLAUDE.md but not README
- Dependabot bulk merge (`D`, `src/repo_tui/dependabot.py`)
- `-s/--sonar` and `-p/--privacy` CLI flags
- Development section (`./test.sh`, `make lint`)
- Troubleshooting for the mouse-tracking leak / `./run-safe.sh`

Also removed the stale `3  Switch to Jira view (if configured)` line from `HELP_TEXT` — no Jira view exists in the codebase.

## Test plan

- `./test.sh` — 53 passed
- pre-commit: ruff, mypy, bandit, gitleaks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX