### PR TITLE
fix(data): surface gh failures instead of rendering repos as clean

### DIFF
--- a/.ast-grep/rules/empty-return-in-except.yml
+++ b/.ast-grep/rules/empty-return-in-except.yml
@@ -1,0 +1,22 @@
+id: empty-return-in-except
+language: python
+severity: error
+note: >-
+  Raise NetworkError (see GitHubClient.get_repo_issues / get_repo_prs in
+  src/repo_tui/data.py) or return None, and let the caller mark the repo as
+  unread. An empty list here renders as a green "clean" status dot.
+message: >-
+  Empty collection returned from an except handler: a failed operation becomes
+  indistinguishable from a legitimately empty result.
+rule:
+  any:
+    - pattern: return []
+    - pattern: return {}
+    - pattern: return set()
+    - pattern: return list()
+    - pattern: return dict()
+    - pattern: return tuple()
+    - pattern: return frozenset()
+  inside:
+    kind: except_clause
+    stopBy: end

--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,6 @@ docs/_templates/
 # ✅ docs/ (documentation)
 # ✅ README.md (project documentation)
 # ✅ .gitignore (this file!)
+
+# Agent scratch notes (not part of the project)
+.agent-notes/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,21 @@ repos:
 
 # Configuration options
 
+  # Structural lint: AST shapes ruff and grep cannot express, e.g. "a return of
+  # an empty collection anywhere inside an except handler" (needs the `inside`
+  # relational operator). Rules live in .ast-grep/rules/.
+  # Whole-tree scan, not new-code-only: the tree is at zero violations, so
+  # there is no backlog to grandfather.
+  - repo: local
+    hooks:
+      - id: ast-grep
+        name: Structural lint (ast-grep)
+        entry: ast-grep scan
+        language: python
+        additional_dependencies: [ast-grep-cli>=0.40.0]
+        types: [python]
+        pass_filenames: false
+
   # Secret scanning — block commits containing API keys, tokens, private keys.
   # Added by add-gitleaks-hook.sh after the 2026-05-10 secret-sprawl audit.
   - repo: https://github.com/gitleaks/gitleaks

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Or use JSON format (`~/.repo-overview.json`):
 - **`debug`**: Enable debug logging for troubleshooting
   - Set to `true` to enable detailed logging:
     - SonarQube API calls: `/tmp/sonar-check-debug.log` and `/tmp/sonar-fetch-debug.log`
+    - PR fetching: `/tmp/pr-fetch-debug.log`
     - Claude launcher: `/tmp/claude-launch-debug.log`
   - Useful for troubleshooting integration issues
   - Default: `false`

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,8 @@
+# ast-grep project config. Rules match AST shapes that ruff and grep cannot
+# express -- e.g. "a return statement anywhere inside an except handler",
+# which needs a relational operator (`inside`), not a text pattern.
+#
+# Run by the "Structural lint" pre-commit hook over the whole tree. The tree is
+# at zero violations, so no baseline file is needed.
+ruleDirs:
+  - .ast-grep/rules

--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -619,6 +619,7 @@ class DependabotMergeScreen(ModalScreen[None]):
         repos_with_prs = 0
         merged = 0
         failed = 0
+        unreadable = 0
 
         async for progress in merge_all_dependabot_prs(self.target_repos):
             if progress.phase == "scanning":
@@ -627,6 +628,10 @@ class DependabotMergeScreen(ModalScreen[None]):
                 continue
 
             if progress.phase == "done":
+                if progress.error:
+                    self._append_log(f"[magenta]◌[/magenta] {progress.repo_name} {progress.error}")
+                    unreadable += 1
+                    continue
                 if not progress.results:
                     self._append_log(f"[dim]- {progress.repo_name} no open Dependabot PRs[/dim]")
                     continue
@@ -659,6 +664,8 @@ class DependabotMergeScreen(ModalScreen[None]):
             f"{repos_with_prs} had Dependabot PRs, "
             f"{merged} merged, {failed} failed"
         )
+        if unreadable:
+            summary += f", {unreadable} unreadable"
         status.update(summary)
         self._append_log("")
         self._append_log(f"[bold]{summary}[/bold]")

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -101,6 +101,7 @@ def _dict_to_repo(d: dict) -> RepoOverview:
         description=d.get("description"),
         friendly_name=d.get("friendly_name"),
         pushed_at=d.get("pushed_at"),
+        fetch_failed=d.get("fetch_failed", False),
     )
 
 
@@ -215,6 +216,13 @@ class GitHubClient:
     def __init__(self, config: Config) -> None:
         self.config = config
 
+    def _debug(self, message: str) -> None:
+        """Append to the PR fetch debug log, but only when debug is enabled."""
+        if not self.config.data.get("debug", False):
+            return
+        with open("/tmp/pr-fetch-debug.log", "a") as f:
+            f.write(message)
+
     async def get_user_repos(self) -> list[dict[str, Any]]:
         """Get all repositories for the authenticated user or organization."""
         try:
@@ -270,10 +278,13 @@ class GitHubClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            stdout, stderr = await proc.communicate()
 
             if proc.returncode != 0:
-                return []
+                raise NetworkError(
+                    f"gh issue list failed for {owner}/{repo} "
+                    f"(exit {proc.returncode}): {stderr.decode().strip()}"
+                )
 
             issues_data = json.loads(stdout.decode())
             return [
@@ -293,14 +304,14 @@ class GitHubClient:
                 for issue in issues_data
                 if issue["state"] == "OPEN"
             ]
-        except Exception:
-            return []
+        except NetworkError:
+            raise
+        except Exception as e:
+            raise NetworkError(f"could not read issues for {owner}/{repo}: {e}") from e
 
     async def get_repo_prs(self, owner: str, repo: str) -> list[PullRequest]:
         """Get open pull requests for a repository."""
-        # Debug: log that we're fetching
-        with open("/tmp/pr-fetch-debug.log", "a") as f:
-            f.write(f"\n=== Fetching PRs for {owner}/{repo} ===\n")
+        self._debug(f"\n=== Fetching PRs for {owner}/{repo} ===\n")
 
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -316,20 +327,18 @@ class GitHubClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            stdout, stderr = await proc.communicate()
 
-            with open("/tmp/pr-fetch-debug.log", "a") as f:
-                f.write(f"Return code: {proc.returncode}\n")
-                f.write(f"Stdout length: {len(stdout)}\n")
+            self._debug(f"Return code: {proc.returncode}\nStdout length: {len(stdout)}\n")
 
             if proc.returncode != 0:
-                with open("/tmp/pr-fetch-debug.log", "a") as f:
-                    f.write("Non-zero return code, returning empty\n")
-                return []
+                raise NetworkError(
+                    f"gh pr list failed for {owner}/{repo} "
+                    f"(exit {proc.returncode}): {stderr.decode().strip()}"
+                )
 
             prs_data = json.loads(stdout.decode())
-            with open("/tmp/pr-fetch-debug.log", "a") as f:
-                f.write(f"Parsed {len(prs_data)} PRs from JSON\n")
+            self._debug(f"Parsed {len(prs_data)} PRs from JSON\n")
 
             result = []
 
@@ -390,20 +399,19 @@ class GitHubClient:
                     )
                 )
 
-            with open("/tmp/pr-fetch-debug.log", "a") as f:
-                f.write(f"Returning {len(result)} PRs\n")
+            self._debug(f"Returning {len(result)} PRs\n")
 
             return result
+        except NetworkError:
+            raise
         except Exception as e:
-            # Debug: log the error to file
-            with open("/tmp/pr-fetch-errors.log", "a") as f:
-                import traceback
+            import traceback
 
-                f.write(f"\n=== ERROR fetching PRs for {owner}/{repo} ===\n")
-                f.write(f"Error: {e}\n")
-                f.write(traceback.format_exc())
-                f.write("\n")
-            return []
+            self._debug(
+                f"\n=== ERROR fetching PRs for {owner}/{repo} ===\n"
+                f"Error: {e}\n{traceback.format_exc()}\n"
+            )
+            raise NetworkError(f"could not read PRs for {owner}/{repo}: {e}") from e
 
     def get_local_repo_path(self, repo_name: str) -> Path | None:
         """Check if repo exists locally and return path."""
@@ -669,7 +677,20 @@ async def fetch_all_repos(
         )
         prs_task = github.get_repo_prs(owner, repo_name)
 
-        issues, pull_requests = await asyncio.gather(issues_task, prs_task)
+        # A gh failure here must not abort the whole sweep — one unreachable repo
+        # shouldn't blank the other 149. Mark it instead, so the status dot can
+        # say "unknown" rather than the green "clean" that empty lists imply.
+        # return_exceptions=True: with the default, the first failure propagates
+        # while the sibling task keeps running unawaited ("exception was never
+        # retrieved" noise on stderr, which corrupts the TUI).
+        issues_result, prs_result = await asyncio.gather(
+            issues_task, prs_task, return_exceptions=True
+        )
+        fetch_failed = isinstance(issues_result, BaseException) or isinstance(
+            prs_result, BaseException
+        )
+        issues = [] if isinstance(issues_result, BaseException) else issues_result
+        pull_requests = [] if isinstance(prs_result, BaseException) else prs_result
 
         local_path = local_scan.by_owner_repo.get((owner.lower(), repo_name.lower()))
         if local_path is None:
@@ -731,6 +752,7 @@ async def fetch_all_repos(
             description=description,
             friendly_name=config.get_friendly_name(repo_name),
             pushed_at=pushed_at,
+            fetch_failed=fetch_failed,
         )
 
     # Process in batches to avoid overwhelming the API
@@ -805,8 +827,13 @@ async def fetch_single_repo(
             pushed_at=pushed_at,
         )
 
-    issues = await github.get_repo_issues(owner, repo_name)
-    pull_requests = await github.get_repo_prs(owner, repo_name)
+    fetch_failed = False
+    try:
+        issues = await github.get_repo_issues(owner, repo_name)
+        pull_requests = await github.get_repo_prs(owner, repo_name)
+    except NetworkError:
+        fetch_failed = True
+        issues, pull_requests = [], []
 
     sonar_status = None
     if check_sonar:
@@ -840,6 +867,7 @@ async def fetch_single_repo(
         has_uncommitted_changes=has_uncommitted,
         current_branch=current_branch,
         friendly_name=config.get_friendly_name(repo_name),
+        fetch_failed=fetch_failed,
     )
 
 
@@ -866,10 +894,16 @@ async def fetch_repo_details(
 
     github = GitHubClient(config)
 
-    issues = await github.get_repo_issues(repo.owner, repo.name)
-    pull_requests = await github.get_repo_prs(repo.owner, repo.name)
+    try:
+        issues = await github.get_repo_issues(repo.owner, repo.name)
+        pull_requests = await github.get_repo_prs(repo.owner, repo.name)
+    except NetworkError:
+        # Leave details_loaded False so expanding again retries the fetch.
+        repo.fetch_failed = True
+        return
 
     repo.issues = issues
     repo.open_issues_count = len(issues)
     repo.pull_requests = pull_requests
     repo.details_loaded = True
+    repo.fetch_failed = False

--- a/src/repo_tui/dependabot.py
+++ b/src/repo_tui/dependabot.py
@@ -29,6 +29,7 @@ class RepoProgress:
     repo_name: str
     phase: str  # "scanning" | "done"
     results: list[MergeResult] = field(default_factory=list)
+    error: str | None = None  # Set when the repo could not be read at all
 
 
 def _is_dependabot_author(author: str | None) -> bool:
@@ -56,8 +57,13 @@ def _summarize_checks(rollup: Any) -> str | None:
     return None
 
 
-async def _list_dependabot_prs(owner: str, repo: str) -> list[dict[str, Any]]:
-    """Live-query open Dependabot PRs for a repo."""
+async def _list_dependabot_prs(owner: str, repo: str) -> list[dict[str, Any]] | None:
+    """Live-query open Dependabot PRs for a repo.
+
+    Returns None when the listing itself failed — an empty list means "no open
+    Dependabot PRs", and reporting that for a failed `gh` call would tell the
+    user a repo is up to date when it may not be.
+    """
     proc = await asyncio.create_subprocess_exec(
         "gh",
         "pr",
@@ -77,12 +83,12 @@ async def _list_dependabot_prs(owner: str, repo: str) -> list[dict[str, Any]]:
     )
     stdout, _ = await proc.communicate()
     if proc.returncode != 0:
-        return []
+        return None
     try:
         data = json.loads(stdout.decode())
     except json.JSONDecodeError:
-        return []
-    return data if isinstance(data, list) else []
+        return None
+    return data if isinstance(data, list) else None
 
 
 def _shorten_reason(stderr_text: str, exit_code: int) -> str:
@@ -150,6 +156,9 @@ async def merge_all_dependabot_prs(
             continue
 
         prs = await _list_dependabot_prs(repo.owner, repo.name)
+        if prs is None:
+            yield RepoProgress(repo.name, "done", [], error="could not list PRs (gh failed)")
+            continue
         if not prs:
             yield RepoProgress(repo.name, "done", [])
             continue

--- a/src/repo_tui/models.py
+++ b/src/repo_tui/models.py
@@ -94,6 +94,10 @@ class RepoOverview:
     description: str | None = None
     friendly_name: str | None = None
     pushed_at: str | None = None
+    # True when the gh calls for issues/PRs failed. Without this, a failed fetch
+    # is indistinguishable from a repo that genuinely has no issues and no PRs,
+    # and the status dot renders green ("clean") for a repo we know nothing about.
+    fetch_failed: bool = False
 
     @property
     def pushed_at_relative(self) -> str | None:

--- a/src/repo_tui/widgets/repo_grid.py
+++ b/src/repo_tui/widgets/repo_grid.py
@@ -38,6 +38,9 @@ class RepoCard(Static):
             pr_label = "PR" if pr_count == 1 else "PRs"
             counts_parts.append(f"[green]{pr_count}[/green] {pr_label}")
         counts = ", ".join(counts_parts) if counts_parts else "[dim]No issues or PRs[/dim]"
+        if repo.fetch_failed:
+            # Not "No issues or PRs" — gh failed, so the counts are unknown.
+            counts = "[magenta]◌ fetch failed[/magenta]"
 
         # Git status
         if repo.local_path:
@@ -72,7 +75,9 @@ class RepoCard(Static):
         # Activity indicator (basic heuristic)
         activity = ""
         total_items = issue_count + pr_count
-        if total_items >= 5:
+        if repo.fetch_failed:
+            activity = ""  # No green "all clear" for a repo we failed to read.
+        elif total_items >= 5:
             activity = "🔥"
         elif total_items >= 2:
             activity = "🟡"

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -95,8 +95,12 @@ class RepoListWidget(OptionList):
 
     def _build_repo_option(self, repo: RepoOverview) -> Option:
         """Build a rich option for a repository."""
+        # Priority 0: gh failed, so issue/PR counts are unknown, not zero. Must
+        # outrank the green "clean" branch below, which empty lists would hit.
+        if repo.fetch_failed:
+            icon = "[magenta]◌[/magenta]"
         # Priority 1: Sonar status (actual code quality issues)
-        if repo.sonar_status and repo.sonar_status.status == "ERROR":
+        elif repo.sonar_status and repo.sonar_status.status == "ERROR":
             icon = "[red]●[/red]"
         elif repo.critical_issue_count >= 5:
             # Priority 2: High number of critical issues (bugs, security, etc.)
@@ -129,6 +133,8 @@ class RepoListWidget(OptionList):
             issue_label = "issue" if issue_count == 1 else "issues"
             counts_parts.append(f"{issue_count} {issue_label}")
         counts_badge = f" [dim]{', '.join(counts_parts)}[/dim]" if counts_parts else ""
+        if repo.fetch_failed:
+            counts_badge = " [magenta]fetch failed[/magenta]"
 
         # Local/remote indicator with branch info
         local = ""

--- a/tests/test_fetch_failures.py
+++ b/tests/test_fetch_failures.py
@@ -1,0 +1,245 @@
+"""A failed gh call must not render as a clean repo.
+
+Before this, get_repo_issues / get_repo_prs returned [] on any failure, so an
+auth error or a network drop produced open_issues_count=0 and pull_requests=[]
+- exactly the shape of a healthy repo, which the status dot paints green.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from repo_tui.config import Config
+from repo_tui.data import (
+    GitHubClient,
+    NetworkError,
+    fetch_all_repos,
+    fetch_repo_details,
+)
+from repo_tui.dependabot import merge_all_dependabot_prs
+from repo_tui.models import RepoOverview
+from repo_tui.widgets.repo_list import RepoListWidget
+
+
+def _config(local_path: Path) -> Config:
+    cfg_path = local_path / ".repo-overview.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "included_repos": [],
+                "excluded_repos": [],
+                "local_code_path": str(local_path),
+                "friendly_names": {},
+            }
+        )
+    )
+    return Config(str(cfg_path))
+
+
+def _gh_repo(name: str = "widget-api", owner: str = "adamkwhite") -> dict:
+    return {
+        "name": name,
+        "owner": {"login": owner},
+        "url": f"https://github.com/{owner}/{name}",
+        "hasIssuesEnabled": True,
+        "primaryLanguage": None,
+        "repositoryTopics": [],
+        "description": None,
+        "pushedAt": "2026-01-01T00:00:00Z",
+    }
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stdout: bytes = b"", stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+# ---------- client raises instead of swallowing ----------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get_repo_issues", "get_repo_prs"])
+async def test_client_raises_on_gh_failure(tmp_path: Path, method: str) -> None:
+    client = GitHubClient(_config(tmp_path))
+    proc = _FakeProc(1, stderr=b"gh: authentication required")
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn,
+        pytest.raises(NetworkError, match="authentication required"),
+    ):
+        spawn.return_value = proc
+        await getattr(client, method)("adamkwhite", "widget-api")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get_repo_issues", "get_repo_prs"])
+async def test_client_raises_on_malformed_json(tmp_path: Path, method: str) -> None:
+    client = GitHubClient(_config(tmp_path))
+    proc = _FakeProc(0, stdout=b"not json at all")
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn,
+        pytest.raises(NetworkError),
+    ):
+        spawn.return_value = proc
+        await getattr(client, method)("adamkwhite", "widget-api")
+
+
+@pytest.mark.asyncio
+async def test_pr_debug_log_not_written_when_debug_disabled(tmp_path: Path) -> None:
+    """Debug logging is opt-in; the old code wrote to /tmp on every fetch."""
+    client = GitHubClient(_config(tmp_path))
+    proc = _FakeProc(0, stdout=b"[]")
+
+    with (
+        patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn,
+        patch("builtins.open") as fake_open,
+    ):
+        spawn.return_value = proc
+        assert await client.get_repo_prs("adamkwhite", "widget-api") == []
+
+    fake_open.assert_not_called()
+
+
+# ---------- fetch marks the repo instead of reporting it clean -------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_repos_marks_failed_repo(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues,
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+        patch("repo_tui.data.save_cache"),
+    ):
+        gh.return_value = [_gh_repo()]
+        issues.side_effect = NetworkError("gh issue list failed")
+        prs.return_value = []
+
+        result = await fetch_all_repos(config)
+
+    assert len(result.repos) == 1
+    assert result.repos[0].fetch_failed is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_repos_one_failure_does_not_sink_the_others(tmp_path: Path) -> None:
+    """A single unreachable repo must not blank out the rest of the sweep."""
+    config = _config(tmp_path)
+
+    async def issues_by_repo(_owner: str, repo: str) -> list:
+        if repo == "broken":
+            raise NetworkError("gh issue list failed")
+        return []
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.GitHubClient.get_repo_issues", side_effect=issues_by_repo),
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+        patch("repo_tui.data.save_cache"),
+    ):
+        gh.return_value = [_gh_repo("broken"), _gh_repo("healthy")]
+        prs.return_value = []
+
+        result = await fetch_all_repos(config)
+
+    by_name = {r.name: r for r in result.repos}
+    assert by_name["broken"].fetch_failed is True
+    assert by_name["healthy"].fetch_failed is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_repo_details_leaves_room_to_retry(tmp_path: Path) -> None:
+    repo = RepoOverview(
+        name="widget-api",
+        owner="adamkwhite",
+        url="https://github.com/adamkwhite/widget-api",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+    )
+
+    with patch(
+        "repo_tui.data.GitHubClient.get_repo_issues",
+        new_callable=AsyncMock,
+    ) as issues:
+        issues.side_effect = NetworkError("gh issue list failed")
+        await fetch_repo_details(_config(tmp_path), repo)
+
+    assert repo.fetch_failed is True
+    # Still unloaded, so expanding the row again re-fetches rather than
+    # cementing the empty state.
+    assert repo.details_loaded is False
+
+
+# ---------- the status dot -------------------------------------------------------
+
+
+def test_failed_repo_does_not_render_as_clean() -> None:
+    widget = RepoListWidget()
+    failed = RepoOverview(
+        name="widget-api",
+        owner="adamkwhite",
+        url="https://github.com/adamkwhite/widget-api",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        fetch_failed=True,
+    )
+
+    rendered = str(widget._build_repo_option(failed).prompt)
+
+    assert "[green]●[/green]" not in rendered
+    assert "fetch failed" in rendered
+
+
+# ---------- dependabot -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dependabot_reports_unreadable_repo() -> None:
+    """gh failing to list PRs must not be reported as 'no open Dependabot PRs'."""
+    repo = RepoOverview(
+        name="widget-api",
+        owner="adamkwhite",
+        url="https://github.com/adamkwhite/widget-api",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        pull_requests=[],
+    )
+    # Cached PR list must look like it has a Dependabot PR, or the fast path
+    # skips the repo before it ever calls gh.
+    from repo_tui.models import PullRequest
+
+    repo.pull_requests = [
+        PullRequest(
+            number=1,
+            title="bump requests",
+            url="",
+            author="app/dependabot",
+            state="OPEN",
+        )
+    ]
+
+    with patch(
+        "repo_tui.dependabot._list_dependabot_prs",
+        new_callable=AsyncMock,
+    ) as listing:
+        listing.return_value = None  # listing failed
+        done = [p async for p in merge_all_dependabot_prs([repo]) if p.phase == "done"]
+
+    assert len(done) == 1
+    assert done[0].error is not None
+    assert done[0].results == []


### PR DESCRIPTION
## Summary

`get_repo_issues` and `get_repo_prs` returned `[]` on any failure, so an auth error, rate limit, or network drop produced `open_issues_count=0` and `pull_requests=[]` — the exact shape of a healthy repo. `_build_repo_option` (`src/repo_tui/widgets/repo_list.py:96`) paints that green "clean", so a repo we could not read at all rendered *better* than one with a single open issue.

Found by porting job-agent's `empty-return-in-except` ast-grep rule to this repo (3 hits).

## Changes

- Both client methods raise `NetworkError`, matching the existing `get_user_repos` contract.
- `fetch_all_repos`, `fetch_single_repo`, and `fetch_repo_details` catch it and set `RepoOverview.fetch_failed`. `asyncio.gather(..., return_exceptions=True)` so one unreachable repo doesn't abort the sweep or leave a sibling task's exception unretrieved (stderr noise corrupts the TUI).
- `fetch_repo_details` leaves `details_loaded=False` on failure, so re-expanding retries instead of cementing the empty state.
- List and grid views render a distinct magenta `◌ fetch failed` marker instead of green.
- `_list_dependabot_prs` returns `None` (not `[]`) on failure; the merge log says "could not list PRs" rather than "no open Dependabot PRs", and the summary counts unreadable repos.
- PR-fetch debug logging is now gated behind `config.debug` — it wrote a log file on **every** fetch, unlike the sonar and launcher logs which already checked the flag.

## Structural lint

Adds `.ast-grep/rules/empty-return-in-except.yml` + `sgconfig.yml`, wired as a pre-commit hook. Whole-tree scan with no baseline — the tree is at zero violations after this PR. Deliberately *not* porting job-agent's `astgrep_new_code.py` CI harness: that exists to gate against a ~100-violation backlog this repo doesn't have.

`sqlite-connect-not-closed` was not ported — no sqlite in this codebase.

## Test plan

- New `tests/test_fetch_failures.py`: client raises on non-zero exit and on malformed JSON, debug log stays unwritten when `debug` is off, failed repo is marked, one failure doesn't sink the sweep, details stay retryable, status dot is never green for a failed repo, Dependabot reports unreadable repos.
- `./test.sh` — 63 passed
- ruff, ruff-format, mypy, `ast-grep scan` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
