### PR TITLE
fix(data): distinguish "unknown" from "clean" for git and Sonar

### DIFF
--- a/src/repo_tui/app.py
+++ b/src/repo_tui/app.py
@@ -69,6 +69,7 @@ HELP_TEXT = """
   [yellow]●[/yellow]             Sonar WARN, uncommitted changes, or 1-4 critical issues
   [blue]●[/blue]             Active PRs or work in progress
   [green]●[/green]             Clean (no issues or uncommitted work)
+  [magenta]◌[/magenta]             Unknown — gh or git failed, so nothing was read
 
 [dim]Critical labels: bug, security, breaking-change, ci-failure, priority-high, status-blocked[/dim]
 [dim]Note: Terminal color schemes may render yellow as orange, blue as purple[/dim]
@@ -1053,7 +1054,7 @@ class RepoOverviewApp(App[None]):
         await asyncio.sleep(0.1)
 
         try:
-            from .data import SonarCloudClient
+            from .data import NetworkError, SonarCloudClient
 
             sonar = SonarCloudClient(self.config)
 
@@ -1063,8 +1064,17 @@ class RepoOverviewApp(App[None]):
 
                 # Try to find sonar project
                 project_keys = sonar.guess_project_key(repo.owner, repo.name)
+                repo.sonar_unreachable = False
                 for project_key in project_keys:
-                    sonar_status = await sonar.get_project_status(project_key)
+                    try:
+                        sonar_status = await sonar.get_project_status(project_key)
+                    except NetworkError:
+                        # Instance is down; the remaining key spellings would
+                        # only repeat the same timeout.
+                        repo.sonar_unreachable = True
+                        repo.sonar_checked = True
+                        repo.sonar_status = None
+                        break
                     if sonar_status:
                         repo.sonar_status = sonar_status
                         repo.sonar_checked = True

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -6,6 +6,7 @@ import asyncio
 import dataclasses
 import json
 import re
+import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Coroutine
@@ -102,6 +103,7 @@ def _dict_to_repo(d: dict) -> RepoOverview:
         friendly_name=d.get("friendly_name"),
         pushed_at=d.get("pushed_at"),
         fetch_failed=d.get("fetch_failed", False),
+        sonar_unreachable=d.get("sonar_unreachable", False),
     )
 
 
@@ -420,11 +422,12 @@ class GitHubClient:
             return local_path
         return None
 
-    async def get_git_status(self, repo_path: Path) -> tuple[bool, str | None]:
+    async def get_git_status(self, repo_path: Path) -> tuple[bool | None, str | None]:
         """Check if repo has uncommitted changes and get current branch.
 
         Returns:
-            tuple: (has_uncommitted_changes, current_branch)
+            tuple: (has_uncommitted_changes, current_branch), where
+            has_uncommitted_changes is None when git could not be run at all.
         """
         try:
             # Check for uncommitted changes (ignoring untracked files)
@@ -440,7 +443,9 @@ class GitHubClient:
             stdout, _ = await proc.communicate()
 
             if proc.returncode != 0:
-                return (False, None)
+                # None, not False: a git that failed to run tells us nothing about
+                # the working tree, and False renders as a clean repo.
+                return (None, None)
 
             # Only count modified/added/deleted tracked files, not untracked files (??)
             status_lines = stdout.decode().strip().split("\n")
@@ -466,7 +471,7 @@ class GitHubClient:
             return (has_changes, current_branch)
 
         except Exception:
-            return (False, None)
+            return (None, None)
 
 
 class SonarCloudClient:
@@ -516,11 +521,19 @@ class SonarCloudClient:
                 url=dashboard_url,
                 conditions=project_status.get("conditions", []),
             )
+        except NetworkError:
+            raise
         except Exception:
+            # Malformed payload for a project that does exist — treat as absent.
             return None
 
     def _fetch_url(self, url: str) -> dict[str, Any] | None:
-        """Fetch URL and return JSON data."""
+        """Fetch URL and return JSON data.
+
+        Returns None when Sonar answers "no such project" (404). Any other
+        failure — timeout, 5xx, bad token, DNS — raises NetworkError, because
+        "we could not ask" must not be reported as "no project here".
+        """
         try:
             request = urllib.request.Request(url)
 
@@ -544,11 +557,18 @@ class SonarCloudClient:
                     with open("/tmp/sonar-fetch-debug.log", "a") as f:
                         f.write(f"Success: {data}\n")
                 return data
+        except urllib.error.HTTPError as e:
+            if self.config.data.get("debug", False):
+                with open("/tmp/sonar-fetch-debug.log", "a") as f:
+                    f.write(f"HTTP {e.code}: {e}\n")
+            if e.code == 404:
+                return None
+            raise NetworkError(f"sonar request failed (HTTP {e.code})") from e
         except Exception as e:
             if self.config.data.get("debug", False):
                 with open("/tmp/sonar-fetch-debug.log", "a") as f:
                     f.write(f"Error: {e}\n")
-            return None
+            raise NetworkError(f"sonar request failed: {e}") from e
 
     def guess_project_key(self, owner: str, repo: str) -> list[str]:
         """Generate possible SonarCloud project keys."""
@@ -704,7 +724,7 @@ async def fetch_all_repos(
         pushed_at = repo_data.get("pushedAt")
 
         # Check git status if repo is local
-        has_uncommitted = False
+        has_uncommitted: bool | None = False
         current_branch = None
         if local_path:
             has_uncommitted, current_branch = await github.get_git_status(local_path)
@@ -712,6 +732,7 @@ async def fetch_all_repos(
         # Check SonarCloud status if enabled
         sonar_status = None
         sonar_checked = False
+        sonar_unreachable = False
         if check_sonar:
             project_keys = sonar.guess_project_key(owner, repo_name)
             # Debug logging (if enabled)
@@ -721,7 +742,13 @@ async def fetch_all_repos(
                     f.write(f"Project keys to try: {project_keys}\n")
 
             for project_key in project_keys:
-                sonar_status = await sonar.get_project_status(project_key)
+                try:
+                    sonar_status = await sonar.get_project_status(project_key)
+                except NetworkError:
+                    # The instance is unreachable, so trying the remaining key
+                    # spellings just repeats the same timeout.
+                    sonar_unreachable = True
+                    break
                 if config.data.get("debug", False):
                     with open("/tmp/sonar-check-debug.log", "a") as f:
                         f.write(f"Tried {project_key}: {sonar_status}\n")
@@ -753,6 +780,7 @@ async def fetch_all_repos(
             friendly_name=config.get_friendly_name(repo_name),
             pushed_at=pushed_at,
             fetch_failed=fetch_failed,
+            sonar_unreachable=sonar_unreachable,
         )
 
     # Process in batches to avoid overwhelming the API
@@ -803,7 +831,7 @@ async def fetch_single_repo(
 
     if owner == LOCAL_ONLY_OWNER:
         path = local_path or github.get_local_repo_path(repo_name)
-        has_uncommitted = False
+        has_uncommitted: bool | None = False
         current_branch = None
         pushed_at = None
         if path:
@@ -836,10 +864,15 @@ async def fetch_single_repo(
         issues, pull_requests = [], []
 
     sonar_status = None
+    sonar_unreachable = False
     if check_sonar:
         project_keys = sonar.guess_project_key(owner, repo_name)
         for project_key in project_keys:
-            sonar_status = await sonar.get_project_status(project_key)
+            try:
+                sonar_status = await sonar.get_project_status(project_key)
+            except NetworkError:
+                sonar_unreachable = True
+                break
             if sonar_status:
                 break
 
@@ -868,6 +901,7 @@ async def fetch_single_repo(
         current_branch=current_branch,
         friendly_name=config.get_friendly_name(repo_name),
         fetch_failed=fetch_failed,
+        sonar_unreachable=sonar_unreachable,
     )
 
 

--- a/src/repo_tui/models.py
+++ b/src/repo_tui/models.py
@@ -89,7 +89,9 @@ class RepoOverview:
     topics: list[str] | None = None
     pull_requests: list[PullRequest] | None = None
     details_loaded: bool = False
-    has_uncommitted_changes: bool = False
+    # None means git could not be run for this checkout, which is not the same
+    # as a clean tree — see GitHubClient.get_git_status.
+    has_uncommitted_changes: bool | None = False
     current_branch: str | None = None
     description: str | None = None
     friendly_name: str | None = None
@@ -98,6 +100,9 @@ class RepoOverview:
     # is indistinguishable from a repo that genuinely has no issues and no PRs,
     # and the status dot renders green ("clean") for a repo we know nothing about.
     fetch_failed: bool = False
+    # Set when the Sonar request itself failed (timeout, 5xx, bad token), as
+    # opposed to the project simply not existing — both used to read "No Sonar".
+    sonar_unreachable: bool = False
 
     @property
     def pushed_at_relative(self) -> str | None:

--- a/src/repo_tui/widgets/repo_grid.py
+++ b/src/repo_tui/widgets/repo_grid.py
@@ -44,7 +44,9 @@ class RepoCard(Static):
 
         # Git status
         if repo.local_path:
-            if repo.has_uncommitted_changes:
+            if repo.has_uncommitted_changes is None:
+                git_status = "[magenta]◌ git status unknown[/magenta]"
+            elif repo.has_uncommitted_changes:
                 git_status = f"[yellow]✱ {repo.current_branch or 'local'}[/yellow]"
             elif repo.current_branch:
                 git_status = f"[dim]⎇ {repo.current_branch}[/dim]"
@@ -71,11 +73,13 @@ class RepoCard(Static):
                 sonar_info = "[yellow]⚠ Sonar[/yellow]"
             elif status == "OK":
                 sonar_info = "[green]✓ Sonar[/green]"
+        elif repo.sonar_unreachable:
+            sonar_info = "[magenta]◌ Sonar unreachable[/magenta]"
 
         # Activity indicator (basic heuristic)
         activity = ""
         total_items = issue_count + pr_count
-        if repo.fetch_failed:
+        if repo.fetch_failed or repo.has_uncommitted_changes is None:
             activity = ""  # No green "all clear" for a repo we failed to read.
         elif total_items >= 5:
             activity = "🔥"

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -97,7 +97,7 @@ class RepoListWidget(OptionList):
         """Build a rich option for a repository."""
         # Priority 0: gh failed, so issue/PR counts are unknown, not zero. Must
         # outrank the green "clean" branch below, which empty lists would hit.
-        if repo.fetch_failed:
+        if repo.fetch_failed or repo.has_uncommitted_changes is None:
             icon = "[magenta]◌[/magenta]"
         # Priority 1: Sonar status (actual code quality issues)
         elif repo.sonar_status and repo.sonar_status.status == "ERROR":
@@ -139,7 +139,9 @@ class RepoListWidget(OptionList):
         # Local/remote indicator with branch info
         local = ""
         if repo.local_path:
-            if repo.has_uncommitted_changes:
+            if repo.has_uncommitted_changes is None:
+                local = " [magenta]git status unknown[/magenta]"
+            elif repo.has_uncommitted_changes:
                 branch_info = f" on {repo.current_branch}" if repo.current_branch else ""
                 local = f" [yellow]✱ uncommitted{branch_info}[/yellow]"
             elif repo.current_branch:
@@ -167,6 +169,9 @@ class RepoListWidget(OptionList):
                 sonar_info = " [yellow]⚠ Quality Gate[/yellow]"
             elif status == "OK":
                 sonar_info = " [green]✓ Sonar[/green]"
+        elif repo.sonar_unreachable:
+            # We asked and could not get an answer — not the same as "no project".
+            sonar_info = " [magenta]◌ Sonar unreachable[/magenta]"
         elif repo.sonar_checked:
             # We checked but no SonarCloud project was found
             sonar_info = " [dim]No Sonar[/dim]"

--- a/tests/test_fetch_failures.py
+++ b/tests/test_fetch_failures.py
@@ -8,6 +8,7 @@ auth error or a network drop produced open_issues_count=0 and pull_requests=[]
 from __future__ import annotations
 
 import json
+import urllib.error
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -202,6 +203,99 @@ def test_failed_repo_does_not_render_as_clean() -> None:
 
     assert "[green]●[/green]" not in rendered
     assert "fetch failed" in rendered
+
+
+# ---------- git status: unknown is not clean -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_git_status_unknown_when_git_fails(tmp_path: Path) -> None:
+    client = GitHubClient(_config(tmp_path))
+
+    with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as spawn:
+        spawn.return_value = _FakeProc(128, stderr=b"fatal: not a git repository")
+        has_changes, branch = await client.get_git_status(tmp_path)
+
+    # None, not False — False is indistinguishable from a clean tree.
+    assert has_changes is None
+    assert branch is None
+
+
+def test_unknown_git_status_does_not_render_as_clean(tmp_path: Path) -> None:
+    widget = RepoListWidget()
+    repo = RepoOverview(
+        name="widget-api",
+        owner="adamkwhite",
+        url="https://github.com/adamkwhite/widget-api",
+        open_issues_count=0,
+        issues=[],
+        sonar_status=None,
+        local_path=str(tmp_path),
+        has_uncommitted_changes=None,
+    )
+
+    rendered = str(widget._build_repo_option(repo).prompt)
+
+    assert "[green]●[/green]" not in rendered
+    assert "git status unknown" in rendered
+
+
+# ---------- sonar: unreachable is not "no project" -------------------------------
+
+
+def test_sonar_404_means_no_project(tmp_path: Path) -> None:
+    """A 404 is a real answer: this project does not exist."""
+    from repo_tui.data import SonarCloudClient
+
+    client = SonarCloudClient(_config(tmp_path))
+    err = urllib.error.HTTPError("https://sonarcloud.io", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+    with patch("urllib.request.urlopen", side_effect=err):
+        assert client._fetch_url("https://sonarcloud.io/api/x") is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        urllib.error.HTTPError("https://sonarcloud.io", 503, "Service Unavailable", {}, None),  # type: ignore[arg-type]
+        urllib.error.URLError("timed out"),
+    ],
+)
+def test_sonar_transport_failure_raises(tmp_path: Path, error: Exception) -> None:
+    from repo_tui.data import SonarCloudClient
+
+    client = SonarCloudClient(_config(tmp_path))
+
+    with patch("urllib.request.urlopen", side_effect=error), pytest.raises(NetworkError):
+        client._fetch_url("https://sonarcloud.io/api/x")
+
+
+@pytest.mark.asyncio
+async def test_unreachable_sonar_is_not_reported_as_no_project(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    with (
+        patch("repo_tui.data.GitHubClient.get_user_repos", new_callable=AsyncMock) as gh,
+        patch("repo_tui.data.GitHubClient.get_repo_issues", new_callable=AsyncMock) as issues,
+        patch("repo_tui.data.GitHubClient.get_repo_prs", new_callable=AsyncMock) as prs,
+        patch("repo_tui.data.SonarCloudClient.get_project_status", new_callable=AsyncMock) as sonar,
+        patch("repo_tui.data.save_cache"),
+    ):
+        gh.return_value = [_gh_repo()]
+        issues.return_value = []
+        prs.return_value = []
+        sonar.side_effect = NetworkError("sonar request failed: timed out")
+
+        result = await fetch_all_repos(config, check_sonar=True)
+
+    repo = result.repos[0]
+    assert repo.sonar_unreachable is True
+    # One attempt, not one per candidate key spelling.
+    assert sonar.await_count == 1
+
+    rendered = str(RepoListWidget()._build_repo_option(repo).prompt)
+    assert "No Sonar" not in rendered
+    assert "Sonar unreachable" in rendered
 
 
 # ---------- dependabot -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Two remaining instances of the shape fixed in #64: a failed read rendering as a healthy repo.

### git status

`get_git_status` returned `(False, None)` when git exited non-zero, so a checkout git could not read showed "no uncommitted changes" and fell through to the green dot. It now returns `(None, None)`; `has_uncommitted_changes` is `bool | None`, and both views render `git status unknown` with the magenta marker. `False` still means genuinely clean — the two are no longer interchangeable.

### Sonar

`_fetch_url` returned `None` for every failure, so a timeout, a 5xx, or a bad token was indistinguishable from a project that was never onboarded — both printed a dim "No Sonar". Only a 404 now means "no project"; everything else raises `NetworkError`, callers set `RepoOverview.sonar_unreachable`, and the views print "Sonar unreachable".

The key-guessing loop (`guess_project_key` returns up to 5 spellings) now breaks on the first `NetworkError` instead of repeating the same 10s timeout for every candidate — worth noting on a 150-repo sweep.

Help text gains a legend row for the magenta unknown marker.

## Test plan

- `test_git_status_unknown_when_git_fails`, `test_unknown_git_status_does_not_render_as_clean`
- `test_sonar_404_means_no_project`, `test_sonar_transport_failure_raises` (503 and URLError), `test_unreachable_sonar_is_not_reported_as_no_project` (also asserts one attempt, not five)
- 69 passed; ruff, mypy, `ast-grep scan` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
