### PR TITLE
docs: align Python version claims and refresh project status

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,8 @@ repos:
         name: Scan for committed secrets (gitleaks)
 
 default_language_version:
+  # Interpreter the hooks run under. Independent of the app's own
+  # requires-python (3.13); any 3.12+ interpreter can host them.
   python: python3.12
 
 # Skip hooks for specific commits

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,27 +269,41 @@ This pattern is especially important in:
 - View switching operations
 - Any operation that calls `_get_current_widget()`
 
+## Failure States (read before touching data.py)
+
+The status dot must never claim a repo is healthy when we simply failed to read
+it. Three flags carry "unknown" through to the widgets:
+
+- `RepoOverview.fetch_failed` — `gh issue list` / `gh pr list` raised
+  `NetworkError`. Renders `◌ fetch failed`, never the green dot.
+- `RepoOverview.has_uncommitted_changes is None` — `git status` could not run.
+  Renders `git status unknown`. `False` means genuinely clean; the two are not
+  interchangeable.
+- `RepoOverview.sonar_unreachable` — the Sonar request failed. Only a 404 means
+  "no project"; everything else raises `NetworkError`.
+
+A `.ast-grep/rules/empty-return-in-except.yml` rule (run by pre-commit) blocks
+the pattern that caused this: returning an empty collection from an except
+handler. Fix the failure contract instead of silencing the rule.
+
 ## Current Status
 
-**Branch:** main (all PRs merged as of 2025-11-29)
-
-**Recent Changes:**
-- Fixed CI/CD pipeline by adding `requirements-dev.txt` with all dev dependencies
-- Added null safety check in Sonar All display update to prevent crashes
-- Applied ruff formatting across all Python files
-- All linting, type checking, and test checks now pass in CI
+**Branch:** main
 
 **Technology Stack:**
-- Python 3.13+ (specified in pyproject.toml)
+- Python 3.13+ (`requires-python` in pyproject.toml; CI tests 3.13 only)
 - Textual 0.40.0+ - Terminal UI framework
 - Rich 13.0.0+ - Terminal formatting
 - PyYAML 6.0+ - YAML config support
 - pytest-asyncio - Async test support (critical for Textual tests)
+- ast-grep - structural lint, rules in `.ast-grep/rules/`
+
+**Features not covered above:** grid view (`1`/`2`), privacy mode (`p`),
+Dependabot bulk merge (`D`, `src/repo_tui/dependabot.py`).
 
 **Known Issues:**
-- None currently - all CI checks passing
+- `launcher.py` is thinly tested (the `wt.exe` path needs subprocess mocking)
 
 **Next Steps:**
 - Monitor SonarCloud integration for any edge cases
-- Consider adding more comprehensive test coverage for widget operations
 - Potential future enhancement: Support both SonarCloud.io and self-hosted SonarQube simultaneously

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Critical issue labels: `bug`, `security`, `breaking-change`, `ci-failure`, `prio
 
 ## Requirements
 
-- Python 3.12+
+- Python 3.13+ (the version CI tests against)
 - `gh` CLI (authenticated)
 - Windows Terminal (for Claude Code launcher)
 - WSL/Ubuntu environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "repo-tui"
 version = "0.1.0"
 description = "Terminal UI for GitHub repository overview with SonarCloud integration"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 license = {text = "MIT"}
 authors = [
     {name = "Adam", email = "adam@example.com"}
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Environment :: Console",
 ]
@@ -89,7 +88,7 @@ known-first-party = ["repo_tui"]
 
 # === MYPY CONFIGURATION ===
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
## Summary

### Python version

Four sources disagreed: `pyproject.toml` said `>=3.12`, README said 3.12+, `CLAUDE.md` said 3.13+, and CI only ever runs 3.13. So 3.12 was advertised but never exercised — anyone installing on it would be the first to find out.

Aligned everything down to what is actually tested: `requires-python = ">=3.13"`, the 3.12 trove classifier dropped, mypy's `python_version` bumped to 3.13, README updated. The alternative (adding 3.12 to the CI matrix) means maintaining support nobody has asked for.

`.pre-commit-config.yaml`'s `default_language_version` stays on python3.12 with a comment explaining why — that is the interpreter hosting the hooks, not the app's runtime floor.

### CLAUDE.md

The Current Status section was dated 2025-11-29, said "Known Issues: None currently", and predated grid view, privacy mode, Dependabot bulk merge, and the failure-state work in #64/#65. Replaced the stale changelog with a **Failure States** section documenting the three "unknown" flags (`fetch_failed`, `has_uncommitted_changes is None`, `sonar_unreachable`) and the ast-grep rule that guards them, since that is the invariant in `data.py` easiest to break by accident.

## Test plan

- `mypy` clean under the 3.13 target
- Docs-only otherwise; no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
