### PR TITLE
ci(sonar): make the SONAR_TOKEN guard actually see the token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,15 @@ jobs:
     permissions:
       contents: read
 
+    # Job level, not step level. The `if: env.SONAR_TOKEN != ''` guards below
+    # are evaluated against the workflow/job env context — a step's own `env:`
+    # block is not visible to that step's own `if:`. With the token defined
+    # only on the steps, the guards read an empty string, both steps skipped
+    # every run, and the job still reported success because a job whose steps
+    # all skipped is a passing job.
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -163,12 +172,18 @@ jobs:
           path: .
         continue-on-error: true
 
+      # Without this, "SonarCloud Analysis: success" on a run where nothing was
+      # analyzed is indistinguishable from a real passing quality gate.
+      - name: Warn when Sonar is not configured
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: |
+          echo "::warning title=SonarCloud skipped::SONAR_TOKEN is not set, so no analysis ran and no quality gate was evaluated. This job's green check does NOT mean the gate passed."
+
       - name: SonarCloud Scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
@@ -179,6 +194,4 @@ jobs:
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: sonarsource/sonarqube-quality-gate-action@master
         timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

The `if: ${{ env.SONAR_TOKEN != '' }}` guards on the Sonar steps are evaluated against the **workflow/job** `env` context, but the token was defined only inside each step's own `env:` block — which is not visible to that step's own `if:`. The workflow-level `env:` holds just `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, so the guards always read an empty string and both steps skipped on every run.

The job still reported **success**, because a job whose steps all skipped is a passing job.

Net effect: every PR merged so far showed `SonarCloud Analysis: success` while no analysis ran and no quality gate was evaluated. Confirmed in run [31950450942](https://github.com/adamkwhite/repo-tui/actions/runs/31950450942):

```
SonarCloud Analysis: success
  SonarCloud Scan               = skipped
  SonarCloud Quality Gate check = skipped
```

## Changes

- `SONAR_TOKEN` hoisted to job-level `env:`, where the `if:` guards can see it. The step-level copies are now redundant and removed — the actions read it from the environment either way.
- New "Warn when Sonar is not configured" step emitting a `::warning::` annotation on the skip path, so a green check with no analysis is visible in the run summary instead of looking identical to a passing gate.

## Caveats

Still inert until a `SONAR_TOKEN` repository secret exists and the SonarCloud project is created — the difference is that it now says so out loud rather than reporting a silent green.

Note this targets **sonarcloud.io**, not the self-hosted instance at `100.74.118.6:9000` that job-agent reports to. Deliberate, per the choice to keep this repo on SonarCloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
