### PR TITLE
ci: gate coverage in CI, since custom Sonar gates are a paid feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Full history: the new-code coverage gate below diffs against the
+          # PR base commit, which a shallow clone does not contain.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -95,6 +99,29 @@ jobs:
             echo "No test files found, skipping pytest"
             echo "This is expected for a template repository"
           fi
+
+      # SonarCloud's free plan cannot assign a custom quality gate, so the
+      # "new code must hit 80%" rule is enforced here instead. diff-cover
+      # scores ONLY the lines this PR adds or changes, which is why the
+      # threshold can be 80% while the project sits at 56% overall — existing
+      # untouched code is exempt, same model as Sonar's new-code period.
+      - name: New-code coverage gate
+        if: github.event_name == 'pull_request' && hashFiles('coverage.xml') != ''
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          # Report even on failure: the whole point is seeing WHICH lines are
+          # uncovered, and a bare non-zero exit does not say.
+          set +e
+          diff-cover coverage.xml \
+            --compare-branch="origin/$BASE_REF" \
+            --fail-under=80 \
+            --markdown-report=diff-cover.md
+          status=$?
+          set -e
+          [ -f diff-cover.md ] && cat diff-cover.md >> "$GITHUB_STEP_SUMMARY"
+          exit $status
 
       # Hand coverage.xml to the downstream `sonarcloud` job so it does not
       # re-run the entire pytest suite (saves ~6 min/PR).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,12 @@ omit = [
 ]
 
 [tool.coverage.report]
+# Ratchet floor, not a target. Set to the measured total at the time it was
+# added so coverage can only go up; raise it when it does. The real bar is the
+# new-code gate in CI (diff-cover, 80% of changed lines) — this only stops
+# silent backsliding, since a total can hold steady while new code goes
+# untested. Local `./test.sh` and CI enforce the same number from here.
+fail_under = 56
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-asyncio>=1.4.0
 mypy>=1.5.0
 types-PyYAML>=6.0.12.20260724
 ruff>=0.3.0
+diff-cover>=9.0.0


### PR DESCRIPTION
## Summary

SonarCloud's free plan will not let a custom quality gate be assigned, so the built-in gate has **no coverage condition at all** — the "new code must hit 80%" standard was enforced nowhere. Two free gates replace it.

### A. New-code gate (the real bar)

`diff-cover` scores **only the lines a PR adds or changes** and fails under 80%. Untouched existing code stays exempt — the same model as Sonar's new-code period, which is why an 80% threshold works while the project sits at 58% overall.

- Requires `fetch-depth: 0` on the test job's checkout; the base commit is not in a shallow clone.
- The markdown report is appended to the job summary **even when the gate fails**, because a bare non-zero exit does not tell you which lines are uncovered.

### B. Total-coverage ratchet (backstop)

`fail_under = 56` in `[tool.coverage.report]`, so `./test.sh` and CI enforce the same floor from one place. It is a ratchet, not a target — a total can hold steady while new code goes untested, which is what gate A is for. Raise it as coverage climbs.

## Verified locally

```
Required test coverage of 56.0% reached. Total coverage: 58.35%    # gate B
```

```
$ diff-cover coverage.xml --compare-branch=origin/main~4 --fail-under=80   # gate A
src/repo_tui/app.py (0.0%): Missing lines 1057,1067,1069-1071,1074-1077
src/repo_tui/data.py (60.7%): Missing lines 474,524-525,562-563,867,871-875
src/repo_tui/widgets/repo_grid.py (83.3%): Missing lines 77
Total:   51 lines
Missing: 21 lines
Coverage: 58%
exit=1
```

Worth knowing: that second run is the last four merged commits, so **this gate would have failed PR #65** — the `action_sonar_all` NetworkError branch in `app.py` went in untested. That is the gate doing its job, but expect it to bite on the next PR touching the modal/action paths in `app.py`.

This PR's own diff touches no Python, so gate A reports "no lines with coverage information" and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
