### PR TITLE
fix(logging): move debug logs out of the shared temp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ claude_command: claude  # Claude CLI command or full path
 privacy_mode: false
 
 # Debug settings
-debug: false  # Enable debug logging (/tmp/sonar-*.log, /tmp/claude-launch-debug.log)
+debug: false  # Enable debug logging to ~/.cache/repo-tui/logs/
 ```
 
 Or use JSON format (`~/.repo-overview.json`):
@@ -171,9 +171,10 @@ Or use JSON format (`~/.repo-overview.json`):
 
 - **`debug`**: Enable debug logging for troubleshooting
   - Set to `true` to enable detailed logging:
-    - SonarQube API calls: `/tmp/sonar-check-debug.log` and `/tmp/sonar-fetch-debug.log`
-    - PR fetching: `/tmp/pr-fetch-debug.log`
-    - Claude launcher: `/tmp/claude-launch-debug.log`
+  - Logs are written to `~/.cache/repo-tui/logs/`:
+    - SonarQube API calls: `sonar-check.log` and `sonar-fetch.log`
+    - PR fetching: `pr-fetch.log`
+    - Claude launcher: `claude-launch.log`
   - Useful for troubleshooting integration issues
   - Default: `false`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ omit = [
 # new-code gate in CI (diff-cover, 80% of changed lines) — this only stops
 # silent backsliding, since a total can hold steady while new code goes
 # untested. Local `./test.sh` and CI enforce the same number from here.
-fail_under = 56
+fail_under = 59
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,12 +132,12 @@ omit = [
 ]
 
 [tool.coverage.report]
-# Ratchet floor, not a target. Set to the measured total at the time it was
-# added so coverage can only go up; raise it when it does. The real bar is the
-# new-code gate in CI (diff-cover, 80% of changed lines) — this only stops
-# silent backsliding, since a total can hold steady while new code goes
-# untested. Local `./test.sh` and CI enforce the same number from here.
-fail_under = 59
+# Ratchet floor, not a target. Set from the number CI measures — the local run
+# reads ~1pp higher, so a floor taken from it fails in CI. Raise it as coverage
+# climbs. The real bar is the new-code gate in CI (diff-cover, 80% of changed
+# lines); this only stops silent backsliding, since a total can hold steady
+# while new code goes untested.
+fail_under = 58
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/src/repo_tui/config.py
+++ b/src/repo_tui/config.py
@@ -14,6 +14,13 @@ except ImportError:
     HAS_YAML = False
 
 
+# Debug logs live beside the repo cache, not in the shared world-writable
+# temp dir: anyone on the box can pre-create or symlink a fixed name there
+# (Sonar python:S5443), and the files vanish on reboot exactly when you want
+# yesterday's log.
+LOG_DIR = Path("~/.cache/repo-tui/logs").expanduser()
+
+
 class Config:
     """Configuration management."""
 
@@ -58,6 +65,24 @@ class Config:
         }
         self._save_config(default_config)
         return default_config
+
+    def debug_log(self, name: str, message: str) -> None:
+        """Append to ~/.cache/repo-tui/logs/<name>.log when debug is enabled.
+
+        Single entry point for every debug log in the app, so the location and
+        the "is debug on?" check live in one place instead of being re-derived
+        at each call site (which is how the PR-fetch log ended up writing
+        unconditionally).
+        """
+        if not self.data.get("debug", False):
+            return
+        try:
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
+            with open(LOG_DIR / f"{name}.log", "a") as f:
+                f.write(message)
+        except OSError:
+            # Diagnostics must never take down the app they are diagnosing.
+            pass
 
     def _save_config(self, config: dict[str, Any]) -> None:
         """Save configuration to file."""

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -220,10 +220,7 @@ class GitHubClient:
 
     def _debug(self, message: str) -> None:
         """Append to the PR fetch debug log, but only when debug is enabled."""
-        if not self.config.data.get("debug", False):
-            return
-        with open("/tmp/pr-fetch-debug.log", "a") as f:
-            f.write(message)
+        self.config.debug_log("pr-fetch", message)
 
     async def get_user_repos(self) -> list[dict[str, Any]]:
         """Get all repositories for the authenticated user or organization."""
@@ -545,29 +542,21 @@ class SonarCloudClient:
                 credentials = base64.b64encode(f"{self.token}:".encode()).decode()
                 request.add_header("Authorization", f"Basic {credentials}")
 
-            # Debug logging (if enabled)
-            if self.config.data.get("debug", False):
-                with open("/tmp/sonar-fetch-debug.log", "a") as f:
-                    f.write(f"\nFetching: {url}\n")
-                    f.write(f"Has token: {bool(self.token)}\n")
+            self.config.debug_log(
+                "sonar-fetch", f"\nFetching: {url}\nHas token: {bool(self.token)}\n"
+            )
 
             with urllib.request.urlopen(request, timeout=10) as response:
                 data: dict[str, Any] = json.loads(response.read().decode())
-                if self.config.data.get("debug", False):
-                    with open("/tmp/sonar-fetch-debug.log", "a") as f:
-                        f.write(f"Success: {data}\n")
+                self.config.debug_log("sonar-fetch", f"Success: {data}\n")
                 return data
         except urllib.error.HTTPError as e:
-            if self.config.data.get("debug", False):
-                with open("/tmp/sonar-fetch-debug.log", "a") as f:
-                    f.write(f"HTTP {e.code}: {e}\n")
+            self.config.debug_log("sonar-fetch", f"HTTP {e.code}: {e}\n")
             if e.code == 404:
                 return None
             raise NetworkError(f"sonar request failed (HTTP {e.code})") from e
         except Exception as e:
-            if self.config.data.get("debug", False):
-                with open("/tmp/sonar-fetch-debug.log", "a") as f:
-                    f.write(f"Error: {e}\n")
+            self.config.debug_log("sonar-fetch", f"Error: {e}\n")
             raise NetworkError(f"sonar request failed: {e}") from e
 
     def guess_project_key(self, owner: str, repo: str) -> list[str]:
@@ -735,11 +724,10 @@ async def fetch_all_repos(
         sonar_unreachable = False
         if check_sonar:
             project_keys = sonar.guess_project_key(owner, repo_name)
-            # Debug logging (if enabled)
-            if config.data.get("debug", False):
-                with open("/tmp/sonar-check-debug.log", "a") as f:
-                    f.write(f"\n=== Checking sonar for {repo_name} ===\n")
-                    f.write(f"Project keys to try: {project_keys}\n")
+            config.debug_log(
+                "sonar-check",
+                f"\n=== Checking sonar for {repo_name} ===\nProject keys to try: {project_keys}\n",
+            )
 
             for project_key in project_keys:
                 try:
@@ -749,16 +737,14 @@ async def fetch_all_repos(
                     # spellings just repeats the same timeout.
                     sonar_unreachable = True
                     break
-                if config.data.get("debug", False):
-                    with open("/tmp/sonar-check-debug.log", "a") as f:
-                        f.write(f"Tried {project_key}: {sonar_status}\n")
+                config.debug_log("sonar-check", f"Tried {project_key}: {sonar_status}\n")
                 if sonar_status:
                     break
             sonar_checked = True
 
-            if config.data.get("debug", False):
-                with open("/tmp/sonar-check-debug.log", "a") as f:
-                    f.write(f"Final: checked={sonar_checked}, status={sonar_status}\n")
+            config.debug_log(
+                "sonar-check", f"Final: checked={sonar_checked}, status={sonar_status}\n"
+            )
 
         return RepoOverview(
             name=repo_name,

--- a/src/repo_tui/launcher.py
+++ b/src/repo_tui/launcher.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import datetime
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -95,16 +97,14 @@ def launch_claude(
         claude_command = config.data.get("claude_command", "claude")
         cmd = build_wt_command(repo, claude_command, issue, pr)
 
-        # Debug logging (if enabled)
-        if config.data.get("debug", False):  # Reuse debug flag
-            with open("/tmp/claude-launch-debug.log", "a") as f:
-                import datetime
-
-                f.write(f"\n=== {datetime.datetime.now()} ===\n")
-                f.write(f"Repo: {repo.name}\n")
-                f.write(f"Local path: {repo.local_path}\n")
-                f.write(f"Claude command: {claude_command}\n")
-                f.write(f"Full command: {cmd}\n")
+        config.debug_log(
+            "claude-launch",
+            f"\n=== {datetime.datetime.now()} ===\n"
+            f"Repo: {repo.name}\n"
+            f"Local path: {repo.local_path}\n"
+            f"Claude command: {claude_command}\n"
+            f"Full command: {cmd}\n",
+        )
 
         subprocess.Popen(
             cmd,
@@ -121,18 +121,11 @@ def launch_claude(
 
     except FileNotFoundError as e:
         error_msg = f"Error: File not found - {e.filename}"
-        if config.data.get("debug", False):
-            with open("/tmp/claude-launch-debug.log", "a") as f:
-                f.write(f"ERROR: {error_msg}\n")
+        config.debug_log("claude-launch", f"ERROR: {error_msg}\n")
         return error_msg
     except Exception as e:
         error_msg = f"Error launching: {e}"
-        if config.data.get("debug", False):
-            with open("/tmp/claude-launch-debug.log", "a") as f:
-                import traceback
-
-                f.write(f"ERROR: {error_msg}\n")
-                f.write(traceback.format_exc())
+        config.debug_log("claude-launch", f"ERROR: {error_msg}\n{traceback.format_exc()}")
         return error_msg
 
 

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -1,0 +1,73 @@
+"""Debug logs are opt-in and live under the user's cache dir, not the temp dir.
+
+A fixed path in a world-writable directory is pre-creatable and symlink-able by
+any other user on the box (Sonar python:S5443), and it evaporates on reboot
+exactly when yesterday's log would have been useful.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from repo_tui import config as config_module
+from repo_tui.config import Config
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path):
+    """Point LOG_DIR at a temp dir so tests never touch the real cache."""
+    target = tmp_path / "logs"
+    with patch.object(config_module, "LOG_DIR", target):
+        yield target
+
+
+def _config(tmp_path: Path, debug: bool) -> Config:
+    cfg_path = tmp_path / ".repo-overview.json"
+    cfg_path.write_text(json.dumps({"debug": debug}))
+    return Config(str(cfg_path))
+
+
+def test_no_file_written_when_debug_disabled(tmp_path: Path, log_dir: Path) -> None:
+    _config(tmp_path, debug=False).debug_log("sonar-fetch", "hello\n")
+
+    assert not log_dir.exists()
+
+
+def test_writes_under_cache_dir_when_enabled(tmp_path: Path, log_dir: Path) -> None:
+    _config(tmp_path, debug=True).debug_log("sonar-fetch", "hello\n")
+
+    assert (log_dir / "sonar-fetch.log").read_text() == "hello\n"
+
+
+def test_appends_rather_than_truncating(tmp_path: Path, log_dir: Path) -> None:
+    config = _config(tmp_path, debug=True)
+    config.debug_log("pr-fetch", "first\n")
+    config.debug_log("pr-fetch", "second\n")
+
+    assert (log_dir / "pr-fetch.log").read_text() == "first\nsecond\n"
+
+
+def test_separate_names_get_separate_files(tmp_path: Path, log_dir: Path) -> None:
+    config = _config(tmp_path, debug=True)
+    config.debug_log("pr-fetch", "a\n")
+    config.debug_log("claude-launch", "b\n")
+
+    assert sorted(p.name for p in log_dir.iterdir()) == ["claude-launch.log", "pr-fetch.log"]
+
+
+@pytest.mark.usefixtures("log_dir")
+def test_unwritable_log_dir_does_not_raise(tmp_path: Path) -> None:
+    """Diagnostics must never take down the app they are diagnosing."""
+    config = _config(tmp_path, debug=True)
+
+    with patch("pathlib.Path.mkdir", side_effect=PermissionError("read-only fs")):
+        config.debug_log("pr-fetch", "hello\n")  # must not raise
+
+
+def test_default_log_dir_is_under_user_cache() -> None:
+    assert Path("~/.cache/repo-tui/logs").expanduser() == config_module.LOG_DIR
+    assert "/tmp" not in str(config_module.LOG_DIR)


### PR DESCRIPTION
## Summary

Sonar `python:S5443`, **14 findings**: every debug log wrote to a fixed path in a world-writable directory, where any other user on the box can pre-create or symlink the name before we open it. They also evaporate on reboot — exactly when yesterday's log would have been useful.

| Before | After |
|---|---|
| `/tmp/sonar-check-debug.log` | `~/.cache/repo-tui/logs/sonar-check.log` |
| `/tmp/sonar-fetch-debug.log` | `~/.cache/repo-tui/logs/sonar-fetch.log` |
| `/tmp/pr-fetch-debug.log` | `~/.cache/repo-tui/logs/pr-fetch.log` |
| `/tmp/claude-launch-debug.log` | `~/.cache/repo-tui/logs/claude-launch.log` |

They now sit beside the existing repo cache (`~/.cache/repo-tui/`, already used by `data.py`).

## One entry point

All writes go through `Config.debug_log(name, message)`. The path and the "is debug on?" check were duplicated across **eleven** call sites, each re-deriving both — which is how the PR-fetch log ended up writing unconditionally (fixed in #64). Consolidating means it cannot drift again, and it clears the duplicated-string-literal findings for those paths as a side effect.

Directory creation is best-effort: a read-only or unwritable cache dir must not take down the app being diagnosed.

## Test plan

New `tests/test_debug_logging.py`: silent when debug is off, writes under the cache dir when on, appends rather than truncates, separate names get separate files, an unwritable dir does not raise, and the default location is under the user cache.

- 92 passed
- New-code coverage **85%** (gate: 80%)
- ruff, mypy, `ast-grep scan` clean
- README updated to document the new paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
