### PR TITLE
ci(sonar): declare src as sources and tests as tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
             -Dsonar.organization=${{ github.repository_owner }}
             -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.sources=src
+            -Dsonar.tests=tests
+            -Dsonar.python.version=3.13
 
       - name: SonarCloud Quality Gate check
         if: ${{ env.SONAR_TOKEN != '' }}


### PR DESCRIPTION
## Summary

The scanner was given no sources/tests split:

```
-Dsonar.projectKey=... -Dsonar.organization=... -Dsonar.python.coverage.reportPaths=coverage.xml
```

So it analyzed the whole tree as production code. `coverage.xml` only measures `src/`, which means **every test file counts as new code with zero coverage**.

Concrete effect on #70: Sonar reported `new_coverage 35.6%` and failed its 80% gate, while `diff-cover` measured the same diff at **85%**. The entire gap was the 77-line test file that PR adds, counted as uncovered production code. Same root cause as the project reading 43.4% overall against 59% locally — `ncloc 4041` includes the test suite.

## Changes

```
-Dsonar.sources=src
-Dsonar.tests=tests
-Dsonar.python.version=3.13
```

The version pin makes Sonar evaluate Python rules against the interpreter CI actually runs, rather than guessing.

## Worth recording

The PR quality gate **does** include `new_coverage` at 80%. Earlier in this work I reported coverage as ungated — that was read off the *branch* status for `main`, which carries only the four rating conditions. Pull requests get the coverage condition from the built-in Sonar way gate. The custom gate that needs a paid plan would let you tune thresholds, but the default already gates PR coverage, and it now agrees with `diff-cover` instead of contradicting it.

## Test plan

CI config only. Verification is #70's Sonar check going green once this lands and that PR is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
