### PR TITLE
ci: run CI when a PR gets new commits, and when workflows change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,15 @@ on:
     paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     branches: [main]
-    types: [opened, reopened, ready_for_review]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
+    # `synchronize` = a new commit pushed to an open PR. Without it CI ran on
+    # the PR's first commit and never again, so every follow-up commit --
+    # review fixes, rebases, the commit that actually breaks something --
+    # merged untested behind a green check from an older tree.
+    types: [opened, reopened, ready_for_review, synchronize]
+    # `.github/**` is deliberately NOT ignored here: a workflow edit is exactly
+    # the change most worth running the workflow on, and ignoring it is how the
+    # missing `synchronize` above survived unnoticed.
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
   workflow_dispatch:  # Allow manual triggers
 
 env:


### PR DESCRIPTION
## Summary

Two trigger gaps, both found the hard way while landing #70.

### 1. `synchronize` was missing

```yaml
types: [opened, reopened, ready_for_review]   # before
```

CI ran on a PR's **first commit and never again**. Every follow-up commit — review fixes, rebases, the commit that actually breaks something — merged behind a green check computed from an older tree.

Observed on #70: after the rebase onto #71 and two further commits, **zero** CI runs fired. The checks displayed were from the original push. I only caught it because a manual `workflow_dispatch` then failed on a coverage floor that the stale green check had never evaluated.

### 2. Workflow changes were ignored on PRs

`paths-ignore` included `.github/**`, so editing a workflow never ran that workflow. That is how the missing `synchronize` survived unnoticed, and why #68 and #71 — both fixes to `ci.yml` — merged with only CodeQL as evidence that they parsed.

Removed from the `pull_request` trigger. The `push` trigger keeps it: re-running the full suite on main after a workflow tweak buys nothing.

## Test plan

Self-verifying. This PR edits `.github/workflows/ci.yml`, so under the old rules CI would skip it entirely; if the full suite runs on this PR, the fix works. Any later commit pushed here exercises `synchronize` the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
