### PR TITLE
refactor(widgets): split the row and card builders into badge functions

### DIFF
--- a/src/repo_tui/widgets/repo_grid.py
+++ b/src/repo_tui/widgets/repo_grid.py
@@ -12,6 +12,77 @@ if TYPE_CHECKING:
     from ..models import RepoOverview
 
 
+# One function per line of the card. Module-level and pure, so each is testable
+# against a RepoOverview without mounting a widget.
+
+
+def card_counts(repo: RepoOverview) -> str:
+    """Issue and PR counts, or the failure marker when they are unknown."""
+    if repo.fetch_failed:
+        # Not "No issues or PRs" — gh failed, so the counts are unknown.
+        return "[magenta]◌ fetch failed[/magenta]"
+
+    parts = []
+    if repo.open_issues_count:
+        label = "issue" if repo.open_issues_count == 1 else "issues"
+        parts.append(f"[cyan]{repo.open_issues_count}[/cyan] {label}")
+    pr_count = len(repo.pull_requests) if repo.pull_requests else 0
+    if pr_count:
+        parts.append(f"[green]{pr_count}[/green] {'PR' if pr_count == 1 else 'PRs'}")
+    return ", ".join(parts) if parts else "[dim]No issues or PRs[/dim]"
+
+
+def card_git_status(repo: RepoOverview) -> str:
+    """Checkout state for the card's second line."""
+    if not repo.local_path:
+        return "[dim]remote[/dim]"
+    if repo.has_uncommitted_changes is None:
+        return "[magenta]◌ git status unknown[/magenta]"
+    if repo.has_uncommitted_changes:
+        return f"[yellow]✱ {repo.current_branch or 'local'}[/yellow]"
+    if repo.current_branch:
+        return f"[dim]⎇ {repo.current_branch}[/dim]"
+    return "[dim]local[/dim]"
+
+
+def card_tags(repo: RepoOverview) -> str:
+    """Language and cloud tags, joined, or empty when the repo has neither."""
+    tags = []
+    if repo.language:
+        tags.append(f"[cyan]{repo.language}[/cyan]")
+    if repo.cloud_env:
+        tags.append(f"[magenta]{repo.cloud_env}[/magenta]")
+    return " · ".join(tags)
+
+
+def card_sonar(repo: RepoOverview) -> str:
+    """Quality gate marker; the card has no room for the failing metric names."""
+    if repo.sonar_status:
+        return {
+            "ERROR": "[red]✗ Sonar[/red]",
+            "WARN": "[yellow]⚠ Sonar[/yellow]",
+            "OK": "[green]✓ Sonar[/green]",
+        }.get(repo.sonar_status.status, "")
+    if repo.sonar_unreachable:
+        return "[magenta]◌ Sonar unreachable[/magenta]"
+    return ""
+
+
+def card_activity(repo: RepoOverview) -> str:
+    """Traffic-light heuristic on open work. Empty when we failed to read the repo."""
+    if repo.fetch_failed or repo.has_uncommitted_changes is None:
+        return ""  # No green "all clear" for a repo we failed to read.
+
+    total = repo.open_issues_count + (len(repo.pull_requests) if repo.pull_requests else 0)
+    if total >= 5:
+        return "🔥"
+    if total >= 2:
+        return "🟡"
+    if total == 0:
+        return "🟢"
+    return ""
+
+
 class RepoCard(Static):
     """A single repository card in the grid."""
 
@@ -23,101 +94,23 @@ class RepoCard(Static):
         self.can_focus = True
 
     def _build_content(self) -> str:
-        """Render the card content."""
+        """Assemble the card from the line builders below."""
         repo = self.repo
 
-        # Build counts
-        issue_count = repo.open_issues_count
-        pr_count = len(repo.pull_requests) if repo.pull_requests else 0
+        lines = ["", f"[bold white]{repo.display_name}[/bold white]", ""]
 
-        counts_parts = []
-        if issue_count > 0:
-            issue_label = "issue" if issue_count == 1 else "issues"
-            counts_parts.append(f"[cyan]{issue_count}[/cyan] {issue_label}")
-        if pr_count > 0:
-            pr_label = "PR" if pr_count == 1 else "PRs"
-            counts_parts.append(f"[green]{pr_count}[/green] {pr_label}")
-        counts = ", ".join(counts_parts) if counts_parts else "[dim]No issues or PRs[/dim]"
-        if repo.fetch_failed:
-            # Not "No issues or PRs" — gh failed, so the counts are unknown.
-            counts = "[magenta]◌ fetch failed[/magenta]"
-
-        # Git status
-        if repo.local_path:
-            if repo.has_uncommitted_changes is None:
-                git_status = "[magenta]◌ git status unknown[/magenta]"
-            elif repo.has_uncommitted_changes:
-                git_status = f"[yellow]✱ {repo.current_branch or 'local'}[/yellow]"
-            elif repo.current_branch:
-                git_status = f"[dim]⎇ {repo.current_branch}[/dim]"
-            else:
-                git_status = "[dim]local[/dim]"
-        else:
-            git_status = "[dim]remote[/dim]"
-
-        # Tags line (language and/or cloud)
-        tags = []
-        if repo.language:
-            tags.append(f"[cyan]{repo.language}[/cyan]")
-        if repo.cloud_env:
-            tags.append(f"[magenta]{repo.cloud_env}[/magenta]")
-        tags_line = " · ".join(tags) if tags else ""
-
-        # SonarCloud status
-        sonar_info = ""
-        if repo.sonar_status:
-            status = repo.sonar_status.status
-            if status == "ERROR":
-                sonar_info = "[red]✗ Sonar[/red]"
-            elif status == "WARN":
-                sonar_info = "[yellow]⚠ Sonar[/yellow]"
-            elif status == "OK":
-                sonar_info = "[green]✓ Sonar[/green]"
-        elif repo.sonar_unreachable:
-            sonar_info = "[magenta]◌ Sonar unreachable[/magenta]"
-
-        # Activity indicator (basic heuristic)
-        activity = ""
-        total_items = issue_count + pr_count
-        if repo.fetch_failed or repo.has_uncommitted_changes is None:
-            activity = ""  # No green "all clear" for a repo we failed to read.
-        elif total_items >= 5:
-            activity = "🔥"
-        elif total_items >= 2:
-            activity = "🟡"
-        elif total_items == 0:
-            activity = "🟢"
-
-        # Build card content - always show name prominently
-        lines = [
-            "",  # Top padding
-            f"[bold white]{repo.display_name}[/bold white]",
-            "",
-        ]
-
-        # Tags (if any)
+        tags_line = card_tags(repo)
         if tags_line:
-            lines.append(tags_line)
-            lines.append("")
+            lines += [tags_line, ""]
 
-        # Always show counts and git status
-        lines.append(counts)
-        lines.append(git_status)
+        lines += [card_counts(repo), card_git_status(repo)]
 
-        # Last push date
         if repo.pushed_at_relative:
             lines.append(f"[dim]{repo.pushed_at_relative}[/dim]")
 
-        # Bottom line: sonar and/or activity
-        bottom_parts = []
-        if sonar_info:
-            bottom_parts.append(sonar_info)
-        if activity:
-            bottom_parts.append(activity)
-
-        if bottom_parts:
-            lines.append("")
-            lines.append(" ".join(bottom_parts))
+        bottom = [part for part in (card_sonar(repo), card_activity(repo)) if part]
+        if bottom:
+            lines += ["", " ".join(bottom)]
 
         return "\n".join(lines)
 

--- a/src/repo_tui/widgets/repo_list.py
+++ b/src/repo_tui/widgets/repo_list.py
@@ -19,6 +19,85 @@ if TYPE_CHECKING:
 
 SPECIAL_ACTION_DEPENDABOT = "dependabot-merge"
 
+# The row is assembled from independent badges. They are module-level and pure
+# so each can be tested against a RepoOverview without mounting a widget, and
+# so the row builder stays a single line of composition per badge.
+
+
+def status_icon(repo: RepoOverview) -> str:
+    """Colored dot summarising the repo, highest-priority signal wins.
+
+    Order matters: "unknown" must outrank the green clean state, or a repo we
+    failed to read renders as healthier than one with a single open issue.
+    """
+    if repo.fetch_failed or repo.has_uncommitted_changes is None:
+        return "[magenta]◌[/magenta]"  # nothing was read; not a verdict
+    if repo.sonar_status and repo.sonar_status.status == "ERROR":
+        return "[red]●[/red]"
+    if repo.critical_issue_count >= 5:
+        return "[red]●[/red]"
+    if repo.sonar_status and repo.sonar_status.status == "WARN":
+        return "[yellow]●[/yellow]"
+    if repo.has_uncommitted_changes:
+        return "[yellow]●[/yellow]"
+    if repo.critical_issue_count > 0:
+        return "[yellow]●[/yellow]"
+    if repo.pull_requests:
+        return "[blue]●[/blue]"  # work in progress
+    return "[green]●[/green]"
+
+
+def counts_badge(repo: RepoOverview) -> str:
+    """ "2 PRs, 3 issues", or the failure marker when the counts are unknown."""
+    if repo.fetch_failed:
+        return " [magenta]fetch failed[/magenta]"
+
+    parts = []
+    pr_count = len(repo.pull_requests) if repo.pull_requests else 0
+    if pr_count:
+        parts.append(f"{pr_count} {'PR' if pr_count == 1 else 'PRs'}")
+    if repo.open_issues_count:
+        parts.append(
+            f"{repo.open_issues_count} {'issue' if repo.open_issues_count == 1 else 'issues'}"
+        )
+    return f" [dim]{', '.join(parts)}[/dim]" if parts else ""
+
+
+def local_badge(repo: RepoOverview) -> str:
+    """Checkout state: branch, uncommitted work, unknown, or remote-only."""
+    if not repo.local_path:
+        return " [dim]\\[remote][/dim]"
+    if repo.has_uncommitted_changes is None:
+        return " [magenta]git status unknown[/magenta]"
+    if repo.has_uncommitted_changes:
+        branch_info = f" on {repo.current_branch}" if repo.current_branch else ""
+        return f" [yellow]✱ uncommitted{branch_info}[/yellow]"
+    if repo.current_branch:
+        return f" [dim]\\[{repo.current_branch}][/dim]"
+    return ""
+
+
+def sonar_badge(repo: RepoOverview) -> str:
+    """Quality gate result, naming the failing metrics when the gate is red."""
+    if repo.sonar_status:
+        status = repo.sonar_status.status
+        if status == "ERROR":
+            failed = [
+                c["metricKey"] for c in repo.sonar_status.conditions if c.get("status") == "ERROR"
+            ]
+            return f" [red]✗ {', '.join(failed[:3]) if failed else 'Quality Gate'}[/red]"
+        if status == "WARN":
+            return " [yellow]⚠ Quality Gate[/yellow]"
+        if status == "OK":
+            return " [green]✓ Sonar[/green]"
+        return ""
+    if repo.sonar_unreachable:
+        # We asked and could not get an answer — not the same as "no project".
+        return " [magenta]◌ Sonar unreachable[/magenta]"
+    if repo.sonar_checked:
+        return " [dim]No Sonar[/dim]"
+    return ""
+
 
 class RepoListWidget(OptionList):
     """Scrollable list of repositories with status indicators."""
@@ -56,23 +135,17 @@ class RepoListWidget(OptionList):
         )
 
         for repo in sorted_repos:
-            option = self._build_repo_option(repo)
-            self.add_option(option)
-
+            self.add_option(self._build_repo_option(repo))
             if repo.name in self.expanded:
-                # Show description first
-                desc_option = self._build_description_option(repo)
-                self.add_option(desc_option)
+                for option in self._expanded_child_options(repo):
+                    self.add_option(option)
 
-                # Show PRs and issues
-                if repo.pull_requests:
-                    for pr in repo.pull_requests:
-                        pr_option = self._build_pr_option(repo, pr)
-                        self.add_option(pr_option)
-                if repo.issues:
-                    for issue in repo.issues:
-                        issue_option = self._build_issue_option(repo, issue)
-                        self.add_option(issue_option)
+    def _expanded_child_options(self, repo: RepoOverview) -> list[Option]:
+        """Rows shown beneath an expanded repo: description, then PRs, then issues."""
+        options = [self._build_description_option(repo)]
+        options += [self._build_pr_option(repo, pr) for pr in repo.pull_requests or []]
+        options += [self._build_issue_option(repo, issue) for issue in repo.issues]
+        return options
 
     def _build_dependabot_action_option(self) -> Option:
         """Build the special pseudo-row that triggers the Dependabot bulk merger."""
@@ -95,94 +168,15 @@ class RepoListWidget(OptionList):
 
     def _build_repo_option(self, repo: RepoOverview) -> Option:
         """Build a rich option for a repository."""
-        # Priority 0: gh failed, so issue/PR counts are unknown, not zero. Must
-        # outrank the green "clean" branch below, which empty lists would hit.
-        if repo.fetch_failed or repo.has_uncommitted_changes is None:
-            icon = "[magenta]◌[/magenta]"
-        # Priority 1: Sonar status (actual code quality issues)
-        elif repo.sonar_status and repo.sonar_status.status == "ERROR":
-            icon = "[red]●[/red]"
-        elif repo.critical_issue_count >= 5:
-            # Priority 2: High number of critical issues (bugs, security, etc.)
-            icon = "[red]●[/red]"
-        elif repo.sonar_status and repo.sonar_status.status == "WARN":
-            icon = "[yellow]●[/yellow]"
-        elif repo.has_uncommitted_changes:
-            # Priority 3: Uncommitted work (needs attention)
-            icon = "[yellow]●[/yellow]"
-        elif repo.critical_issue_count > 0:
-            # Priority 4: Some critical issues
-            icon = "[yellow]●[/yellow]"
-        elif repo.pull_requests:
-            # Priority 5: Active PRs (work in progress)
-            icon = "[blue]●[/blue]"
-        else:
-            # Clean state
-            icon = "[green]●[/green]"
-
         expand_icon = "▼" if repo.name in self.expanded else "▶"
-        issue_count = repo.open_issues_count
-        pr_count = len(repo.pull_requests) if repo.pull_requests else 0
-
-        # Build counts display
-        counts_parts = []
-        if pr_count > 0:
-            pr_label = "PR" if pr_count == 1 else "PRs"
-            counts_parts.append(f"{pr_count} {pr_label}")
-        if issue_count > 0:
-            issue_label = "issue" if issue_count == 1 else "issues"
-            counts_parts.append(f"{issue_count} {issue_label}")
-        counts_badge = f" [dim]{', '.join(counts_parts)}[/dim]" if counts_parts else ""
-        if repo.fetch_failed:
-            counts_badge = " [magenta]fetch failed[/magenta]"
-
-        # Local/remote indicator with branch info
-        local = ""
-        if repo.local_path:
-            if repo.has_uncommitted_changes is None:
-                local = " [magenta]git status unknown[/magenta]"
-            elif repo.has_uncommitted_changes:
-                branch_info = f" on {repo.current_branch}" if repo.current_branch else ""
-                local = f" [yellow]✱ uncommitted{branch_info}[/yellow]"
-            elif repo.current_branch:
-                local = f" [dim]\\[{repo.current_branch}][/dim]"
-        else:
-            local = " [dim]\\[remote][/dim]"
-
-        # Language and cloud env tags
         lang_tag = f" [cyan]\\[{repo.language}][/cyan]" if repo.language else ""
         cloud_tag = f" [magenta]\\[{repo.cloud_env}][/magenta]" if repo.cloud_env else ""
-
-        # SonarCloud status indicator
-        sonar_info = ""
-        if repo.sonar_status:
-            status = repo.sonar_status.status
-            if status == "ERROR":
-                failed = [
-                    c["metricKey"]
-                    for c in repo.sonar_status.conditions
-                    if c.get("status") == "ERROR"
-                ]
-                failed_text = ", ".join(failed[:3]) if failed else "Quality Gate"
-                sonar_info = f" [red]✗ {failed_text}[/red]"
-            elif status == "WARN":
-                sonar_info = " [yellow]⚠ Quality Gate[/yellow]"
-            elif status == "OK":
-                sonar_info = " [green]✓ Sonar[/green]"
-        elif repo.sonar_unreachable:
-            # We asked and could not get an answer — not the same as "no project".
-            sonar_info = " [magenta]◌ Sonar unreachable[/magenta]"
-        elif repo.sonar_checked:
-            # We checked but no SonarCloud project was found
-            sonar_info = " [dim]No Sonar[/dim]"
-
-        # Last push date
-        pushed_tag = ""
-        if repo.pushed_at_relative:
-            pushed_tag = f" [dim]{repo.pushed_at_relative}[/dim]"
+        pushed_tag = f" [dim]{repo.pushed_at_relative}[/dim]" if repo.pushed_at_relative else ""
 
         text = Text.from_markup(
-            f"{icon} {expand_icon} {repo.display_name}{lang_tag}{cloud_tag}{counts_badge}{local}{pushed_tag}{sonar_info}"
+            f"{status_icon(repo)} {expand_icon} {repo.display_name}"
+            f"{lang_tag}{cloud_tag}{counts_badge(repo)}{local_badge(repo)}"
+            f"{pushed_tag}{sonar_badge(repo)}"
         )
         return Option(text, id=f"repo:{repo.name}")
 
@@ -270,26 +264,49 @@ class RepoListWidget(OptionList):
                 self.highlighted = i
                 break
 
-    def get_selected_repo(self) -> RepoOverview | None:
-        """Get the currently selected repository."""
+    def _highlighted_option_id(self) -> str | None:
+        """Option id of the highlighted row, or None if nothing is highlighted."""
         selected = self.highlighted
         if selected is None:
             return None
-
         option = self.get_option_at_index(selected)
-        if not option or not option.id:
+        return option.id if option else None
+
+    def _repo_by_name(self, name: str) -> RepoOverview | None:
+        return next((repo for repo in self.repos if repo.name == name), None)
+
+    def _selected_child_row(self, prefix: str) -> tuple[RepoOverview, int] | None:
+        """Resolve a `<prefix>:<repo>:<number>` row to its repo and number.
+
+        Both inline-child getters below parse the same id shape, so the parsing
+        (and its failure modes: no selection, wrong row type, malformed id,
+        unknown repo) lives here once.
+        """
+        option_id = self._highlighted_option_id()
+        if not option_id or not option_id.startswith(f"{prefix}:"):
             return None
 
-        if option.id.startswith("repo:"):
-            repo_name = option.id.split(":", 1)[1]
-        elif option.id.startswith("issue:") or option.id.startswith("pr:"):
-            repo_name = option.id.split(":")[1]
-        else:
+        parts = option_id.split(":")
+        if len(parts) < 3:
+            return None
+        try:
+            number = int(parts[2])
+        except ValueError:
             return None
 
-        for repo in self.repos:
-            if repo.name == repo_name:
-                return repo
+        repo = self._repo_by_name(parts[1])
+        return (repo, number) if repo else None
+
+    def get_selected_repo(self) -> RepoOverview | None:
+        """Get the currently selected repository."""
+        option_id = self._highlighted_option_id()
+        if not option_id:
+            return None
+
+        # Child rows carry their parent repo name in the same position, so an
+        # issue or PR row still resolves to the repo it belongs to.
+        if option_id.startswith(("repo:", "issue:", "pr:")):
+            return self._repo_by_name(option_id.split(":")[1])
         return None
 
     def get_selected_inline_issue(self) -> tuple[RepoOverview, Issue] | None:
@@ -297,58 +314,24 @@ class RepoListWidget(OptionList):
 
         Returns (repo, issue) tuple or None if a repo row is selected.
         """
-        selected = self.highlighted
-        if selected is None:
+        match = self._selected_child_row("issue")
+        if not match:
             return None
-
-        option = self.get_option_at_index(selected)
-        if not option or not option.id:
-            return None
-
-        if option.id.startswith("issue:"):
-            parts = option.id.split(":")
-            if len(parts) >= 3:
-                repo_name = parts[1]
-                try:
-                    issue_number = int(parts[2])
-                except ValueError:
-                    return None
-
-                for repo in self.repos:
-                    if repo.name == repo_name:
-                        for issue in repo.issues:
-                            if issue.number == issue_number:
-                                return (repo, issue)
-        return None
+        repo, number = match
+        issue = next((i for i in repo.issues if i.number == number), None)
+        return (repo, issue) if issue else None
 
     def get_selected_inline_pr(self) -> tuple[RepoOverview, PullRequest] | None:
         """Get the PR if an inline PR is selected.
 
         Returns (repo, pr) tuple or None if a repo/issue row is selected.
         """
-        selected = self.highlighted
-        if selected is None:
+        match = self._selected_child_row("pr")
+        if not match:
             return None
-
-        option = self.get_option_at_index(selected)
-        if not option or not option.id:
-            return None
-
-        if option.id.startswith("pr:"):
-            parts = option.id.split(":")
-            if len(parts) >= 3:
-                repo_name = parts[1]
-                try:
-                    pr_number = int(parts[2])
-                except ValueError:
-                    return None
-
-                for repo in self.repos:
-                    if repo.name == repo_name and repo.pull_requests:
-                        for pr in repo.pull_requests:
-                            if pr.number == pr_number:
-                                return (repo, pr)
-        return None
+        repo, number = match
+        pr = next((p for p in (repo.pull_requests or []) if p.number == number), None)
+        return (repo, pr) if pr else None
 
     def on_option_list_option_highlighted(
         self,

--- a/tests/test_row_badges.py
+++ b/tests/test_row_badges.py
@@ -1,0 +1,227 @@
+"""The badge builders extracted from the list row and the grid card.
+
+They were branches inside two 40-line render functions, which meant the only
+way to assert "a repo we could not read never renders green" was to build a
+widget and scrape markup out of it. As plain functions the priority order is
+directly assertable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repo_tui.models import Issue, PullRequest, RepoOverview, SonarStatus
+from repo_tui.widgets.repo_grid import (
+    card_activity,
+    card_counts,
+    card_git_status,
+    card_sonar,
+    card_tags,
+)
+from repo_tui.widgets.repo_list import counts_badge, local_badge, sonar_badge, status_icon
+
+
+def _repo(**kwargs) -> RepoOverview:
+    defaults = {
+        "name": "widget-api",
+        "owner": "adamkwhite",
+        "url": "https://github.com/adamkwhite/widget-api",
+        "open_issues_count": 0,
+        "issues": [],
+        "sonar_status": None,
+    }
+    return RepoOverview(**{**defaults, **kwargs})
+
+
+def _bug(number: int = 1) -> Issue:
+    return Issue(number=number, title="t", url="u", labels=["bug"], state="OPEN")
+
+
+def _pr(number: int = 1) -> PullRequest:
+    return PullRequest(number=number, title="t", url="u", author="a", state="OPEN")
+
+
+def _sonar(status: str, conditions: list[dict[str, str]] | None = None) -> SonarStatus:
+    return SonarStatus(project_key="k", status=status, url="u", conditions=conditions or [])
+
+
+# ---------- status_icon: priority order ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected"),
+    [
+        (_repo(fetch_failed=True), "magenta"),
+        (_repo(local_path="/x", has_uncommitted_changes=None), "magenta"),
+        (_repo(sonar_status=_sonar("ERROR")), "red"),
+        (_repo(issues=[_bug(i) for i in range(5)]), "red"),
+        (_repo(sonar_status=_sonar("WARN")), "yellow"),
+        (_repo(local_path="/x", has_uncommitted_changes=True), "yellow"),
+        (_repo(issues=[_bug()]), "yellow"),
+        (_repo(pull_requests=[_pr()]), "blue"),
+        (_repo(), "green"),
+    ],
+)
+def test_status_icon_colors(repo: RepoOverview, expected: str) -> None:
+    assert expected in status_icon(repo)
+
+
+def test_unknown_outranks_every_healthy_signal() -> None:
+    """A repo we could not read must never win the green dot on a technicality."""
+    unread = _repo(fetch_failed=True, pull_requests=[], issues=[], sonar_status=_sonar("OK"))
+
+    assert "green" not in status_icon(unread)
+    assert "magenta" in status_icon(unread)
+
+
+def test_sonar_error_outranks_a_single_critical_issue() -> None:
+    repo = _repo(sonar_status=_sonar("ERROR"), issues=[_bug()])
+    assert "red" in status_icon(repo)
+
+
+# ---------- counts ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected"),
+    [
+        (_repo(), ""),
+        (_repo(open_issues_count=1), "1 issue"),
+        (_repo(open_issues_count=3), "3 issues"),
+        (_repo(pull_requests=[_pr()]), "1 PR"),
+        (_repo(pull_requests=[_pr(1), _pr(2)]), "2 PRs"),
+    ],
+)
+def test_counts_badge_pluralization(repo: RepoOverview, expected: str) -> None:
+    assert expected in counts_badge(repo)
+
+
+def test_counts_badge_reports_failure_over_zero() -> None:
+    repo = _repo(fetch_failed=True, open_issues_count=0)
+    assert "fetch failed" in counts_badge(repo)
+
+
+# ---------- local / git state -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected"),
+    [
+        (_repo(), "remote"),
+        (_repo(local_path="/x", has_uncommitted_changes=None), "git status unknown"),
+        (_repo(local_path="/x", has_uncommitted_changes=True, current_branch="fix/a"), "fix/a"),
+        (_repo(local_path="/x", has_uncommitted_changes=True), "uncommitted"),
+        (_repo(local_path="/x", current_branch="main"), "main"),
+        (_repo(local_path="/x"), ""),
+    ],
+)
+def test_local_badge(repo: RepoOverview, expected: str) -> None:
+    assert expected in local_badge(repo)
+
+
+def test_unknown_git_state_is_not_reported_as_clean() -> None:
+    unknown = _repo(local_path="/x", has_uncommitted_changes=None)
+    clean = _repo(local_path="/x", current_branch="main")
+
+    assert local_badge(unknown) != local_badge(clean)
+    assert "unknown" in local_badge(unknown)
+
+
+# ---------- sonar -----------------------------------------------------------------
+
+
+def test_sonar_badge_names_the_failing_metrics() -> None:
+    repo = _repo(
+        sonar_status=_sonar(
+            "ERROR",
+            [
+                {"metricKey": "new_coverage", "status": "ERROR"},
+                {"metricKey": "new_bugs", "status": "OK"},
+            ],
+        )
+    )
+    badge = sonar_badge(repo)
+
+    assert "new_coverage" in badge
+    assert "new_bugs" not in badge  # passing conditions are not failures
+
+
+def test_sonar_badge_caps_the_metric_list() -> None:
+    conditions = [{"metricKey": f"m{i}", "status": "ERROR"} for i in range(6)]
+    badge = sonar_badge(_repo(sonar_status=_sonar("ERROR", conditions)))
+
+    assert badge.count(",") == 2  # three metrics, so two separators
+
+
+def test_unreachable_is_not_no_project() -> None:
+    unreachable = sonar_badge(_repo(sonar_unreachable=True, sonar_checked=True))
+    absent = sonar_badge(_repo(sonar_checked=True))
+
+    assert "unreachable" in unreachable
+    assert "No Sonar" in absent
+    assert unreachable != absent
+
+
+def test_sonar_badge_empty_when_never_checked() -> None:
+    assert sonar_badge(_repo()) == ""
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [("WARN", "⚠ Quality Gate"), ("OK", "✓ Sonar"), ("NONE", "")],
+)
+def test_sonar_badge_non_error_states(status: str, expected: str) -> None:
+    badge = sonar_badge(_repo(sonar_status=_sonar(status)))
+    assert expected in badge if expected else badge == ""
+
+
+# ---------- grid card -------------------------------------------------------------
+
+
+def test_card_counts_matches_list_semantics() -> None:
+    assert "fetch failed" in card_counts(_repo(fetch_failed=True))
+    assert "No issues or PRs" in card_counts(_repo())
+    # The card colors the number separately, so the count and its label are
+    # split by markup: "[cyan]1[/cyan] issue".
+    assert card_counts(_repo(open_issues_count=1)).endswith(" issue")
+    assert card_counts(_repo(open_issues_count=2)).endswith(" issues")
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected"),
+    [
+        (_repo(), "remote"),
+        (_repo(local_path="/x", has_uncommitted_changes=None), "git status unknown"),
+        (_repo(local_path="/x", has_uncommitted_changes=True), "local"),
+        (_repo(local_path="/x", current_branch="main"), "main"),
+        (_repo(local_path="/x"), "local"),
+    ],
+)
+def test_card_git_status(repo: RepoOverview, expected: str) -> None:
+    assert expected in card_git_status(repo)
+
+
+def test_card_tags_joins_only_what_exists() -> None:
+    assert card_tags(_repo()) == ""
+    assert card_tags(_repo(language="Python")) == "[cyan]Python[/cyan]"
+    assert " · " in card_tags(_repo(language="Python", topics=["aws"]))
+
+
+@pytest.mark.parametrize(
+    ("repo", "expected"),
+    [
+        (_repo(), "🟢"),
+        (_repo(open_issues_count=2), "🟡"),
+        (_repo(open_issues_count=5), "🔥"),
+        (_repo(open_issues_count=1), ""),
+        (_repo(fetch_failed=True), ""),
+        (_repo(local_path="/x", has_uncommitted_changes=None), ""),
+    ],
+)
+def test_card_activity(repo: RepoOverview, expected: str) -> None:
+    assert card_activity(repo) == expected
+
+
+def test_card_sonar_unknown_status_renders_nothing() -> None:
+    assert card_sonar(_repo(sonar_status=_sonar("NONE"))) == ""
+    assert "unreachable" in card_sonar(_repo(sonar_unreachable=True))

--- a/tests/test_row_selection.py
+++ b/tests/test_row_selection.py
@@ -1,0 +1,159 @@
+"""Resolving the highlighted row back to the repo, issue, or PR it stands for.
+
+Every action key (`o`, `c`, `e`) routes through these, and an expanded repo
+interleaves child rows with repo rows, so "which thing is under the cursor"
+is the question the whole keymap depends on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repo_tui.app import RepoOverviewApp
+from repo_tui.models import Issue, PullRequest, RepoOverview
+from repo_tui.widgets.repo_list import RepoListWidget
+
+
+def _repo(name: str = "widget-api", *, issues=None, prs=None) -> RepoOverview:
+    return RepoOverview(
+        name=name,
+        owner="adamkwhite",
+        url=f"https://github.com/adamkwhite/{name}",
+        open_issues_count=len(issues or []),
+        issues=issues or [],
+        sonar_status=None,
+        pull_requests=prs or [],
+    )
+
+
+def _issue(number: int) -> Issue:
+    return Issue(number=number, title=f"issue {number}", url="u", labels=[], state="OPEN")
+
+
+def _pr(number: int) -> PullRequest:
+    return PullRequest(number=number, title=f"pr {number}", url="u", author="a", state="OPEN")
+
+
+async def _widget_with(repos: list[RepoOverview], expanded: set[str] | None = None):
+    """Mount the app and return (pilot ctx, widget) with repos loaded."""
+    app = RepoOverviewApp()
+    ctx = app.run_test()
+    pilot = await ctx.__aenter__()
+    await pilot.pause()
+    widget = app.query_one("#repo-list", RepoListWidget)
+    if expanded:
+        widget.expanded = set(expanded)
+    widget.set_repos(repos)
+    await pilot.pause()
+    return ctx, widget
+
+
+def _index_of(widget: RepoListWidget, option_id: str) -> int:
+    for i in range(widget.option_count):
+        option = widget.get_option_at_index(i)
+        if option and option.id == option_id:
+            return i
+    raise AssertionError(f"no row with id {option_id}")
+
+
+@pytest.mark.asyncio
+async def test_child_rows_resolve_to_their_issue_and_pr() -> None:
+    repo = _repo(issues=[_issue(1), _issue(2)], prs=[_pr(7)])
+    ctx, widget = await _widget_with([repo], expanded={"widget-api"})
+    try:
+        widget.highlighted = _index_of(widget, "issue:widget-api:2")
+        match = widget.get_selected_inline_issue()
+        assert match is not None
+        assert match[0].name == "widget-api"
+        assert match[1].number == 2
+        # An issue row is not a PR row.
+        assert widget.get_selected_inline_pr() is None
+
+        widget.highlighted = _index_of(widget, "pr:widget-api:7")
+        pr_match = widget.get_selected_inline_pr()
+        assert pr_match is not None
+        assert pr_match[1].number == 7
+        assert widget.get_selected_inline_issue() is None
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_child_row_still_resolves_to_its_parent_repo() -> None:
+    """`o` on an issue row must know which repo the issue belongs to."""
+    repo = _repo(issues=[_issue(1)])
+    ctx, widget = await _widget_with([repo], expanded={"widget-api"})
+    try:
+        widget.highlighted = _index_of(widget, "issue:widget-api:1")
+        selected = widget.get_selected_repo()
+        assert selected is not None
+        assert selected.name == "widget-api"
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_repo_row_is_not_an_inline_child() -> None:
+    repo = _repo(issues=[_issue(1)], prs=[_pr(1)])
+    ctx, widget = await _widget_with([repo], expanded={"widget-api"})
+    try:
+        widget.highlighted = _index_of(widget, "repo:widget-api")
+        assert widget.get_selected_inline_issue() is None
+        assert widget.get_selected_inline_pr() is None
+        assert widget.get_selected_repo() is not None
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_action_row_resolves_to_nothing() -> None:
+    ctx, widget = await _widget_with([_repo()])
+    try:
+        widget.highlighted = 0  # the Dependabot pseudo-row
+        assert widget.get_selected_repo() is None
+        assert widget.get_selected_inline_issue() is None
+        assert widget.get_selected_inline_pr() is None
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_nothing_highlighted_resolves_to_nothing() -> None:
+    ctx, widget = await _widget_with([_repo()])
+    try:
+        widget.highlighted = None
+        assert widget.get_selected_repo() is None
+        assert widget.get_selected_inline_issue() is None
+        assert widget.get_selected_inline_pr() is None
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_expanded_rows_are_description_then_prs_then_issues() -> None:
+    repo = _repo(issues=[_issue(1)], prs=[_pr(9)])
+    ctx, widget = await _widget_with([repo], expanded={"widget-api"})
+    try:
+        ids = [
+            widget.get_option_at_index(i).id  # type: ignore[union-attr]
+            for i in range(widget.option_count)
+        ]
+        assert ids[1] == "repo:widget-api"
+        assert ids[3] == "pr:widget-api:9"
+        assert ids[4] == "issue:widget-api:1"
+    finally:
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_collapsed_repo_shows_no_child_rows() -> None:
+    repo = _repo(issues=[_issue(1)], prs=[_pr(9)])
+    ctx, widget = await _widget_with([repo])
+    try:
+        ids = [
+            widget.get_option_at_index(i).id  # type: ignore[union-attr]
+            for i in range(widget.option_count)
+        ]
+        assert ids == ["action:dependabot-merge", "repo:widget-api"]
+    finally:
+        await ctx.__aexit__(None, None, None)


### PR DESCRIPTION
## Summary

Sonar `python:S3776` — the five worst offenders in the codebase, all in the widgets:

| Function | Before | After |
|---|---|---|
| `_build_repo_option` | **43** | 3 |
| `_build_content` (card) | **36** | 6 |
| `get_selected_inline_pr` | **28** | 3 |
| `get_selected_inline_issue` | **27** | 3 |
| `_rebuild_options` | **18** | 6 |

(Threshold is 15.)

### Rendering

Each row and card is assembled from small pure functions — `status_icon`, `counts_badge`, `local_badge`, `sonar_badge` for the list; `card_counts`, `card_git_status`, `card_tags`, `card_sonar`, `card_activity` for the grid. They take a `RepoOverview` and return markup.

The payoff is testability of the invariant this session has been circling: the status-dot priority order, where "we could not read this repo" must outrank the green clean state. That was previously assertable only by building a widget and scraping markup out of its `Option`. It is now a direct call.

### Selection

`get_selected_inline_issue` and `get_selected_inline_pr` were the same 20-line parse of `<kind>:<repo>:<number>` with the type swapped. Both now call `_selected_child_row(prefix)`, so the four failure modes — nothing highlighted, wrong row type, malformed id, unknown repo — are handled once rather than twice. `get_selected_repo` folds its three id shapes into one, since child rows carry the parent repo name in the same position.

**No behaviour change**: same markup, same priority order, same option ids.

## Test plan

Two new files, 51 tests:

- `test_row_badges.py` — the full priority ladder of `status_icon` as a parametrized table, pluralization, failure states never rendering as clean, sonar naming failing metrics and capping at three, and the grid equivalents.
- `test_row_selection.py` — child rows resolving to their issue/PR, a child row still resolving to its parent repo (what `o` depends on), repo rows not resolving as children, the Dependabot action row and an empty selection resolving to nothing, and expansion ordering (description, PRs, issues).

- 144 passed
- New-code coverage **96%** (gate: 80%)
- ruff, mypy, `ast-grep scan` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
