### PR TITLE
fix: finish the Sonar sweep — grid debug writes and the last two hotspots

### DIFF
--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -695,6 +695,69 @@ async def _cached_result(config: Config, github: GitHubClient) -> FetchResult:
     return FetchResult(repos=cached_repos, is_cached=True, cache_timestamp=timestamp)
 
 
+async def _fetch_repo_overview(
+    config: Config,
+    github: GitHubClient,
+    sonar: SonarCloudClient,
+    local_scan: LocalRepoScan,
+    repo_data: dict[str, Any],
+    check_sonar: bool,
+) -> RepoOverview:
+    """Build one repo's overview: issues, PRs, local git state, Sonar."""
+    repo_name = repo_data["name"]
+    owner = repo_data["owner"]["login"]
+
+    issues, pull_requests, fetch_failed = await _fetch_issues_and_prs(
+        github, owner, repo_name, has_issues=repo_data.get("hasIssuesEnabled", True)
+    )
+
+    local_path = local_scan.by_owner_repo.get((owner.lower(), repo_name.lower()))
+    if local_path is None:
+        # Fall back to directory-name match for repos with no remote URL set.
+        local_path = github.get_local_repo_path(repo_name)
+    primary_lang = repo_data.get("primaryLanguage")
+    language = primary_lang.get("name") if primary_lang else None
+    topics_data = repo_data.get("repositoryTopics", [])
+    topics = [t["name"] for t in topics_data] if topics_data else None
+    description = repo_data.get("description")
+    pushed_at = repo_data.get("pushedAt")
+
+    # Check git status if repo is local
+    has_uncommitted: bool | None = False
+    current_branch = None
+    if local_path:
+        has_uncommitted, current_branch = await github.get_git_status(local_path)
+
+    sonar_result = (
+        await check_sonar_status(config, sonar, owner, repo_name)
+        if check_sonar
+        else SonarCheck(None, checked=False, unreachable=False)
+    )
+
+    return RepoOverview(
+        name=repo_name,
+        owner=owner,
+        url=repo_data["url"],
+        open_issues_count=len(issues),
+        issues=issues,
+        sonar_status=sonar_result.status,
+        is_private=repo_data.get("isPrivate", False),
+        local_path=str(local_path) if local_path else None,
+        sonar_checked=sonar_result.checked,
+        language=language,
+        topics=topics,
+        pull_requests=pull_requests,
+        details_loaded=True,
+        has_uncommitted_changes=has_uncommitted,
+        current_branch=current_branch,
+        description=description,
+        friendly_name=config.get_friendly_name(repo_name),
+        pushed_at=pushed_at,
+        fetch_failed=fetch_failed,
+        sonar_unreachable=sonar_result.unreachable,
+    )
+
+
 async def fetch_all_repos(
     config: Config,
     check_sonar: bool = False,
@@ -735,61 +798,7 @@ async def fetch_all_repos(
     # whose origin isn't on GitHub at all.
     local_scan = await scan_local_repos(config.get_local_code_path())
 
-    # Parallel fetch: create tasks for all repos
-    async def fetch_repo_data(repo_data: dict[str, Any]) -> RepoOverview:
-        repo_name = repo_data["name"]
-        owner = repo_data["owner"]["login"]
-
-        issues, pull_requests, fetch_failed = await _fetch_issues_and_prs(
-            github, owner, repo_name, has_issues=repo_data.get("hasIssuesEnabled", True)
-        )
-
-        local_path = local_scan.by_owner_repo.get((owner.lower(), repo_name.lower()))
-        if local_path is None:
-            # Fall back to directory-name match for repos with no remote URL set.
-            local_path = github.get_local_repo_path(repo_name)
-        primary_lang = repo_data.get("primaryLanguage")
-        language = primary_lang.get("name") if primary_lang else None
-        topics_data = repo_data.get("repositoryTopics", [])
-        topics = [t["name"] for t in topics_data] if topics_data else None
-        description = repo_data.get("description")
-        pushed_at = repo_data.get("pushedAt")
-
-        # Check git status if repo is local
-        has_uncommitted: bool | None = False
-        current_branch = None
-        if local_path:
-            has_uncommitted, current_branch = await github.get_git_status(local_path)
-
-        sonar_result = (
-            await check_sonar_status(config, sonar, owner, repo_name)
-            if check_sonar
-            else SonarCheck(None, checked=False, unreachable=False)
-        )
-
-        return RepoOverview(
-            name=repo_name,
-            owner=owner,
-            url=repo_data["url"],
-            open_issues_count=len(issues),
-            issues=issues,
-            sonar_status=sonar_result.status,
-            is_private=repo_data.get("isPrivate", False),
-            local_path=str(local_path) if local_path else None,
-            sonar_checked=sonar_result.checked,
-            language=language,
-            topics=topics,
-            pull_requests=pull_requests,
-            details_loaded=True,
-            has_uncommitted_changes=has_uncommitted,
-            current_branch=current_branch,
-            description=description,
-            friendly_name=config.get_friendly_name(repo_name),
-            pushed_at=pushed_at,
-            fetch_failed=fetch_failed,
-            sonar_unreachable=sonar_result.unreachable,
-        )
-
+    # Parallel fetch: one task per repo, batched below.
     # Process in batches to avoid overwhelming the API
     batch_size = 10
     for i in range(0, total, batch_size):
@@ -797,7 +806,12 @@ async def fetch_all_repos(
         if progress_callback:
             await progress_callback(i + len(batch), total, f"batch {i // batch_size + 1}")
 
-        batch_results = await asyncio.gather(*[fetch_repo_data(r) for r in batch])
+        batch_results = await asyncio.gather(
+            *[
+                _fetch_repo_overview(config, github, sonar, local_scan, r, check_sonar)
+                for r in batch
+            ]
+        )
         overviews.extend(batch_results)
 
     # Add local-only repos (dirs with no GitHub remote) so they show up alongside

--- a/src/repo_tui/dependabot.py
+++ b/src/repo_tui/dependabot.py
@@ -144,22 +144,27 @@ async def merge_all_dependabot_prs(
             yield RepoProgress(repo.name, "done", [])
             continue
 
-        results: list[MergeResult] = []
-        for pr in prs:
-            pr_number = pr.get("number")
-            if not isinstance(pr_number, int):
-                continue
-            pr_title = pr.get("title", "")
+        yield RepoProgress(repo.name, "done", await _merge_listed_prs(repo, prs))
 
-            blocked = _preflight_reason(pr)
-            if blocked:
-                results.append(MergeResult(pr_number, pr_title, False, blocked))
-                continue
 
-            success, reason = await _merge_pr(repo.owner, repo.name, pr_number)
-            results.append(MergeResult(pr_number, pr_title, success, reason))
+async def _merge_listed_prs(repo: RepoOverview, prs: list[dict[str, Any]]) -> list[MergeResult]:
+    """Pre-flight then merge each PR, returning one result per PR attempted."""
+    results: list[MergeResult] = []
+    for pr in prs:
+        pr_number = pr.get("number")
+        if not isinstance(pr_number, int):
+            continue  # malformed entry; nothing to merge or report
+        pr_title = pr.get("title", "")
 
-        yield RepoProgress(repo.name, "done", results)
+        blocked = _preflight_reason(pr)
+        if blocked:
+            results.append(MergeResult(pr_number, pr_title, False, blocked))
+            continue
+
+        success, reason = await _merge_pr(repo.owner, repo.name, pr_number)
+        results.append(MergeResult(pr_number, pr_title, success, reason))
+
+    return results
 
 
 def _preflight_reason(pr: dict[str, Any]) -> str | None:

--- a/src/repo_tui/widgets/repo_grid.py
+++ b/src/repo_tui/widgets/repo_grid.py
@@ -171,14 +171,9 @@ class RepoGridWidget(VerticalScroll):
         # Sort repos (same logic as list view)
         sorted_repos = sorted(repos, key=lambda r: r.pushed_at or "", reverse=True)
 
-        # Debug: log to file
-        with open("/tmp/grid_debug.log", "a") as f:
-            f.write("\n=== set_repos called ===\n")
-            f.write(f"Total repos: {len(sorted_repos)}\n")
-            for i, repo in enumerate(sorted_repos[:10]):
-                f.write(
-                    f"  {i}: {repo.name} - issues:{repo.open_issues_count} branch:{repo.current_branch}\n"
-                )
+        # Textual's own logger, not a file: this ran on every render, ungated by
+        # the debug flag, into a fixed path in the shared temp dir.
+        self.log(f"grid set_repos: {len(sorted_repos)} repos")
 
         # Create cards
         for repo in sorted_repos:
@@ -187,11 +182,10 @@ class RepoGridWidget(VerticalScroll):
                 grid.mount(card)
                 self._cards.append(card)
             except Exception as e:
-                with open("/tmp/grid_debug.log", "a") as f:
-                    f.write(f"ERROR creating card for {repo.name}: {e}\n")
+                # One malformed repo must not leave the grid empty.
+                self.log.error(f"grid card failed for {repo.name}: {e}")
 
-        with open("/tmp/grid_debug.log", "a") as f:
-            f.write(f"Created {len(self._cards)} cards successfully\n")
+        self.log(f"grid mounted {len(self._cards)} cards")
 
         # Focus first card if any
         if self._cards:


### PR DESCRIPTION
## Summary

Closes out the two items from the Sonar baseline. Both had a tail I missed on the first pass.

### Three more temp-dir writes (`python:S5443`)

They survived because they are named `grid_debug.log` and my grep matched `-debug.log` with a hyphen. They were also **worse** than the ones fixed in #70: completely ungated by the debug flag, so every grid render appended a dump of the first ten repos to a fixed path in a world-writable directory.

Replaced with Textual's own logger. A widget has no `Config` handle to check the debug flag against, and this output belongs in the devtools console rather than a file nobody reads. The card-creation failure now logs at error level instead of vanishing silently.

### The last two complexity hotspots (`python:S3776`)

| Function | Before | After | How |
|---|---|---|---|
| `fetch_all_repos` | 18 | 6 | nested `fetch_repo_data` lifted to module level as `_fetch_repo_overview` — nested defs count toward the parent's score |
| `merge_all_dependabot_prs` | 16 | 9 | per-repo merge loop → `_merge_listed_prs`, leaving the generator as loop + yields |

## Result

**Every function in the codebase is now under the complexity threshold, and no source file writes to the shared temp dir.**

Sonar on `main` before this PR: 2 × S3776, 3 × S5443 open. After: zero of both.

## Test plan

- 181 passed
- New-code coverage **94%** (gate: 80%)
- ruff, mypy, `ast-grep scan` clean
- `grep -rn 'open("/t' src/` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
