### PR TITLE
refactor(logging): make debug log names a closed, enforced set

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,19 @@ Or use JSON format (`~/.repo-overview.json`):
 
 - **`debug`**: Enable debug logging for troubleshooting
   - Set to `true` to enable detailed logging:
-  - Logs are written to `~/.cache/repo-tui/logs/`:
-    - SonarQube API calls: `sonar-check.log` and `sonar-fetch.log`
-    - PR fetching: `pr-fetch.log`
-    - Claude launcher: `claude-launch.log`
-  - Useful for troubleshooting integration issues
+  - Logs are written to `~/.cache/repo-tui/logs/`, one file per subsystem:
+
+    | File | Contents |
+    |------|----------|
+    | `pr-fetch.log` | `gh pr list` calls and their results |
+    | `sonar-check.log` | which project keys were tried for each repo |
+    | `sonar-fetch.log` | raw SonarQube API requests and responses |
+    | `claude-launch.log` | the `wt.exe` command line and launch errors |
+
+  - Names follow `<subsystem>-<action>.log`. They are declared in the
+    `DebugLog` enum in `src/repo_tui/config.py` and written only through
+    `Config.debug_log()` — adding a log means adding an enum member, which
+    the test suite checks against the convention.
   - Default: `false`
 
 ### Example Configurations

--- a/src/repo_tui/config.py
+++ b/src/repo_tui/config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import re
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +21,26 @@ except ImportError:
 # (Sonar python:S5443), and the files vanish on reboot exactly when you want
 # yesterday's log.
 LOG_DIR = Path("~/.cache/repo-tui/logs").expanduser()
+
+# Every debug log the app writes. A closed set rather than a free-form string
+# because the names drifted once already: three writes went to a
+# `grid_debug.log` that matched neither the location nor the naming of the
+# rest, and nothing flagged it.
+#
+# Convention: <subsystem>-<action>, lowercase, hyphen-separated, no extension
+# (`.log` is appended when the file is opened). Enforced by LOG_NAME_RE below,
+# which is asserted over this enum in the test suite — so a member that breaks
+# the convention fails CI rather than silently creating an odd file.
+LOG_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)+$")
+
+
+class DebugLog(StrEnum):
+    """Names of the debug logs, one per subsystem that writes one."""
+
+    PR_FETCH = "pr-fetch"
+    SONAR_CHECK = "sonar-check"
+    SONAR_FETCH = "sonar-fetch"
+    CLAUDE_LAUNCH = "claude-launch"
 
 
 class Config:
@@ -66,19 +88,27 @@ class Config:
         self._save_config(default_config)
         return default_config
 
-    def debug_log(self, name: str, message: str) -> None:
+    def debug_log(self, name: DebugLog | str, message: str) -> None:
         """Append to ~/.cache/repo-tui/logs/<name>.log when debug is enabled.
 
-        Single entry point for every debug log in the app, so the location and
-        the "is debug on?" check live in one place instead of being re-derived
-        at each call site (which is how the PR-fetch log ended up writing
-        unconditionally).
+        Single entry point for every debug log in the app, so the location, the
+        naming, and the "is debug on?" check live in one place instead of being
+        re-derived at each call site — which is how the PR-fetch log ended up
+        writing unconditionally, and how grid_debug.log ended up in the temp
+        dir under a different naming scheme entirely.
+
+        `name` must be a DebugLog member. A plain string is accepted for
+        convenience and coerced, which raises ValueError for anything not in
+        the enum: adding a log means adding a member, not inventing a filename
+        at the call site. mypy catches it first; this catches the untyped path.
         """
+        log_name = DebugLog(name)
+
         if not self.data.get("debug", False):
             return
         try:
             LOG_DIR.mkdir(parents=True, exist_ok=True)
-            with open(LOG_DIR / f"{name}.log", "a") as f:
+            with open(LOG_DIR / f"{log_name.value}.log", "a") as f:
                 f.write(message)
         except OSError:
             # Diagnostics must never take down the app they are diagnosing.

--- a/src/repo_tui/data.py
+++ b/src/repo_tui/data.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from .config import Config
+from .config import Config, DebugLog
 from .models import Issue, PullRequest, RepoOverview, SonarStatus
 
 if TYPE_CHECKING:
@@ -295,7 +295,7 @@ async def check_sonar_status(
     """
     project_keys = sonar.guess_project_key(owner, repo_name)
     config.debug_log(
-        "sonar-check",
+        DebugLog.SONAR_CHECK,
         f"\n=== Checking sonar for {repo_name} ===\nProject keys to try: {project_keys}\n",
     )
 
@@ -304,11 +304,11 @@ async def check_sonar_status(
             status = await sonar.get_project_status(project_key)
         except NetworkError:
             return SonarCheck(None, checked=True, unreachable=True)
-        config.debug_log("sonar-check", f"Tried {project_key}: {status}\n")
+        config.debug_log(DebugLog.SONAR_CHECK, f"Tried {project_key}: {status}\n")
         if status:
             return SonarCheck(status, checked=True, unreachable=False)
 
-    config.debug_log("sonar-check", f"Final: checked=True, status=None ({repo_name})\n")
+    config.debug_log(DebugLog.SONAR_CHECK, f"Final: checked=True, status=None ({repo_name})\n")
     return SonarCheck(None, checked=True, unreachable=False)
 
 
@@ -320,7 +320,7 @@ class GitHubClient:
 
     def _debug(self, message: str) -> None:
         """Append to the PR fetch debug log, but only when debug is enabled."""
-        self.config.debug_log("pr-fetch", message)
+        self.config.debug_log(DebugLog.PR_FETCH, message)
 
     async def get_user_repos(self) -> list[dict[str, Any]]:
         """Get all repositories for the authenticated user or organization."""
@@ -570,20 +570,20 @@ class SonarCloudClient:
                 request.add_header("Authorization", f"Basic {credentials}")
 
             self.config.debug_log(
-                "sonar-fetch", f"\nFetching: {url}\nHas token: {bool(self.token)}\n"
+                DebugLog.SONAR_FETCH, f"\nFetching: {url}\nHas token: {bool(self.token)}\n"
             )
 
             with urllib.request.urlopen(request, timeout=10) as response:
                 data: dict[str, Any] = json.loads(response.read().decode())
-                self.config.debug_log("sonar-fetch", f"Success: {data}\n")
+                self.config.debug_log(DebugLog.SONAR_FETCH, f"Success: {data}\n")
                 return data
         except urllib.error.HTTPError as e:
-            self.config.debug_log("sonar-fetch", f"HTTP {e.code}: {e}\n")
+            self.config.debug_log(DebugLog.SONAR_FETCH, f"HTTP {e.code}: {e}\n")
             if e.code == 404:
                 return None
             raise NetworkError(f"sonar request failed (HTTP {e.code})") from e
         except Exception as e:
-            self.config.debug_log("sonar-fetch", f"Error: {e}\n")
+            self.config.debug_log(DebugLog.SONAR_FETCH, f"Error: {e}\n")
             raise NetworkError(f"sonar request failed: {e}") from e
 
     def guess_project_key(self, owner: str, repo: str) -> list[str]:

--- a/src/repo_tui/launcher.py
+++ b/src/repo_tui/launcher.py
@@ -9,6 +9,7 @@ import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .config import DebugLog  # runtime use, not just typing
 from .models import Issue, PullRequest, RepoOverview
 
 if TYPE_CHECKING:
@@ -98,7 +99,7 @@ def launch_claude(
         cmd = build_wt_command(repo, claude_command, issue, pr)
 
         config.debug_log(
-            "claude-launch",
+            DebugLog.CLAUDE_LAUNCH,
             f"\n=== {datetime.datetime.now()} ===\n"
             f"Repo: {repo.name}\n"
             f"Local path: {repo.local_path}\n"
@@ -121,11 +122,11 @@ def launch_claude(
 
     except FileNotFoundError as e:
         error_msg = f"Error: File not found - {e.filename}"
-        config.debug_log("claude-launch", f"ERROR: {error_msg}\n")
+        config.debug_log(DebugLog.CLAUDE_LAUNCH, f"ERROR: {error_msg}\n")
         return error_msg
     except Exception as e:
         error_msg = f"Error launching: {e}"
-        config.debug_log("claude-launch", f"ERROR: {error_msg}\n{traceback.format_exc()}")
+        config.debug_log(DebugLog.CLAUDE_LAUNCH, f"ERROR: {error_msg}\n{traceback.format_exc()}")
         return error_msg
 
 

--- a/tests/test_debug_log_names.py
+++ b/tests/test_debug_log_names.py
@@ -1,0 +1,118 @@
+"""The debug-log naming convention, enforced rather than documented.
+
+The names drifted once: three writes went to `grid_debug.log`, which matched
+neither the location nor the naming of the other four, and nothing caught it.
+A closed enum plus these tests means a new log has to join the set, and a
+member that breaks the convention fails CI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from repo_tui import config as config_module
+from repo_tui.config import LOG_NAME_RE, Config, DebugLog
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path):
+    target = tmp_path / "logs"
+    with patch.object(config_module, "LOG_DIR", target):
+        yield target
+
+
+def _config(tmp_path: Path, debug: bool = True) -> Config:
+    cfg = tmp_path / ".repo-overview.json"
+    cfg.write_text(json.dumps({"debug": debug}))
+    return Config(str(cfg))
+
+
+# ---------- the convention --------------------------------------------------------
+
+
+@pytest.mark.parametrize("member", list(DebugLog))
+def test_every_name_follows_the_convention(member: DebugLog) -> None:
+    """<subsystem>-<action>: lowercase, hyphen-separated, no extension."""
+    assert LOG_NAME_RE.match(member.value), (
+        f"{member.name} = {member.value!r} breaks the convention"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "grid_debug",  # underscores — the exact drift this replaces
+        "grid-debug.log",  # extension belongs to the writer, not the name
+        "PR-Fetch",  # uppercase
+        "prfetch",  # no subsystem/action split
+        "pr--fetch",  # empty segment
+        "-pr-fetch",  # leading separator
+        "pr-fetch-",  # trailing separator
+    ],
+)
+def test_convention_rejects_malformed_names(bad: str) -> None:
+    assert not LOG_NAME_RE.match(bad)
+
+
+def test_names_are_unique() -> None:
+    values = [m.value for m in DebugLog]
+    assert len(values) == len(set(values))
+
+
+# ---------- enforcement at the writer ---------------------------------------------
+
+
+def test_unknown_name_is_rejected(tmp_path: Path, log_dir: Path) -> None:
+    """Adding a log means adding an enum member, not inventing a filename."""
+    with pytest.raises(ValueError):
+        _config(tmp_path).debug_log("grid_debug", "hello\n")
+
+    assert not log_dir.exists()
+
+
+@pytest.mark.usefixtures("log_dir")
+def test_unknown_name_is_rejected_even_when_debug_is_off(tmp_path: Path) -> None:
+    """The typo is a bug whether or not logging happens to be on."""
+    with pytest.raises(ValueError):
+        _config(tmp_path, debug=False).debug_log("nope", "hello\n")
+
+
+def test_plain_string_matching_a_member_is_accepted(tmp_path: Path, log_dir: Path) -> None:
+    _config(tmp_path).debug_log("pr-fetch", "hello\n")
+
+    assert (log_dir / "pr-fetch.log").read_text() == "hello\n"
+
+
+@pytest.mark.parametrize("member", list(DebugLog))
+def test_each_member_writes_its_own_file(tmp_path: Path, log_dir: Path, member: DebugLog) -> None:
+    _config(tmp_path).debug_log(member, "x\n")
+
+    assert [p.name for p in log_dir.iterdir()] == [f"{member.value}.log"]
+
+
+def test_enum_is_the_full_set_of_logs_written() -> None:
+    """Guards against a log being added to the enum but never wired up, and
+    against source writing a log filename that bypasses debug_log entirely."""
+    src = Path(__file__).resolve().parent.parent / "src" / "repo_tui"
+    sources = "\n".join(p.read_text() for p in src.rglob("*.py"))
+
+    for member in DebugLog:
+        constant = f"DebugLog.{member.name}"
+        assert constant in sources, f"{constant} is declared but never used"
+
+    # config.py holds the only open() of a log file; every other module has to
+    # go through debug_log, so a new log cannot skip the naming rule.
+    # A log *filename* is a string literal ending in .log — distinct from
+    # `self.log(...)` (Textual's logger) or `self.log_lines` (the merge modal).
+    filename_literal = re.compile(r"""\.log['"]""")
+    for path in src.rglob("*.py"):
+        if path.name == "config.py":
+            continue
+        assert not filename_literal.search(path.read_text()), (
+            f"{path.name} names a log file directly instead of using debug_log"
+        )


### PR DESCRIPTION
## Summary

The names drifted once already: three writes went to `grid_debug.log`, matching neither the location nor the naming of the other four, and nothing flagged it — the grep that found the rest looked for `-debug.log` with a hyphen. A free-form `str` parameter meant the convention lived only in the head of whoever wrote the last call site.

**Convention**: `<subsystem>-<action>`, lowercase, hyphen-separated, no extension (`.log` is appended by the writer).

| Name | Contents |
|---|---|
| `pr-fetch` | `gh pr list` calls and their results |
| `sonar-check` | which project keys were tried for each repo |
| `sonar-fetch` | raw SonarQube API requests and responses |
| `claude-launch` | the `wt.exe` command line and launch errors |

## Enforcement, in layers

1. **`DebugLog` StrEnum** is the only source of names. Every call site passes a member, so **mypy** rejects a typo before it runs.
2. **`Config.debug_log` coerces** through `DebugLog()`, so an untyped string that is not a member raises `ValueError` — including when debug is off, since the typo is a bug either way.
3. **A test asserts every member matches `LOG_NAME_RE`**, so a member that breaks the convention fails CI rather than quietly creating an odd file.
4. **A test asserts no module outside `config.py` contains a `.log` filename literal** — this is the one that would have caught `grid_debug.log`. It matches string literals ending in `.log`, so it does not trip on `self.log(...)` (Textual's logger) or `self.log_lines` (the merge modal).
5. **A test asserts every declared member is actually used**, so the enum cannot accumulate dead entries.

The negative cases are pinned explicitly, including `grid_debug` itself and the near-misses (`PR-Fetch`, `pr--fetch`, `-pr-fetch`, `pr-fetch-`, `grid-debug.log`).

## Test plan

- New `tests/test_debug_log_names.py` (20 tests)
- 201 passed
- New-code coverage **95%** (gate: 80%)
- ruff, mypy, `ast-grep scan` clean
- README documents the files and the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBn5XoFri8Urz23XJuaqeX
